### PR TITLE
フォロー登録・解除を非同期通信へ変更

### DIFF
--- a/app/Http/Controllers/LikesController.php
+++ b/app/Http/Controllers/LikesController.php
@@ -10,6 +10,7 @@ class LikesController extends Controller
     public function store($id)
     {
         $user = \Auth::user();
+        $auth_id = $user->id;
         $like = $user->like($id);
         $post = Post::findOrFail($id);
 
@@ -21,6 +22,7 @@ class LikesController extends Controller
                             'like' => true,
                             'p_count' => $p_count,
                             'u_count' => $u_count,
+                            'auth_id' => $auth_id,
                         ]);
         }
 
@@ -32,6 +34,7 @@ class LikesController extends Controller
                             'unlike' => false,
                             'p_count' => $p_count,
                             'u_count' => $u_count,
+                            'auth_id' => $auth_id,
                         ]);
         }
     }

--- a/app/Http/Controllers/UserFollowController.php
+++ b/app/Http/Controllers/UserFollowController.php
@@ -7,12 +7,32 @@ use Illuminate\Http\Request;
 class UserFollowController extends Controller
 {
     public function store($id) {
-        \Auth::user()->follow($id);
-        return back()->with('msg_success', 'フォローしました');
-    }
+        $user = \Auth::user();
+        $auth_id = $user->id;
+        $follow = $user->follow($id);
 
-    public function destroy($id) {
-        \Auth::user()->unfollow($id);
-        return back()->with('msg_success', 'フォローを外しました');
+        //フォローの場合
+        if ($follow === true) {
+            $follow_count = $user->followings()->count();
+            $follower_count = $user->followers()->count();
+            return response()->json([
+                            'follow' => true,
+                            'follow_count' => $follow_count,
+                            'follower_count' => $follower_count,
+                            'auth_id' => $auth_id,
+                        ]);
+        }
+
+        //アンフォローの場合
+        elseif ($follow === false) {
+            $follow_count = $user->followings()->count();
+            $follower_count = $user->followers()->count();
+            return response()->json([
+                            'unfollow' => false,
+                            'follow_count' => $follow_count,
+                            'follower_count' => $follower_count,
+                            'auth_id' => $auth_id,
+                        ]);
+        }
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -58,31 +58,18 @@ class User extends Authenticatable
         return $this->belongsToMany(User::class, 'user_follow', 'follow_id', 'user_id')->withTimestamps();
     }
 
-    //フォロー処理
+    //フォロー・アンフォロー処理
     public function follow($user_id) {
-        $exist = $this->isFollowing($user_id);
-        $its_me = $this->id === $user_id;
-
-        if($exist || $its_me) {
-            return false;
-        }
-        else {
-            $this->followings()->attach($user_id);
-            return true;
-        }
-    }
-
-    //フォローを外す処理
-    public function unfollow($user_id) {
         $exist = $this->isFollowing($user_id);
         $its_me = $this->id === $user_id;
 
         if($exist && !$its_me) {
             $this->followings()->detach($user_id);
-            return true;
-        }
-        else {
             return false;
+        }
+        elseif(!$exist && !$its_me) {
+            $this->followings()->attach($user_id);
+            return true;
         }
     }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17283,13 +17283,19 @@ button.toast-close-button {
 }
 
 @media (max-width: 315px) {
-  .follow_button,
-  .action_follow {
-    font-size: 10px;
+  .follow_button:hover {
+    background-color: #d0211c;
+    border-color: #c51f1a;
+    font-size: 0 !important;
   }
 
-  .unfollow_button {
-    font-size: 9px;
+  .follow_button:hover:before {
+    font-size: 10px !important;
+    content: "\30D5\30A9\30ED\30FC\89E3\9664" !important;
+  }
+
+  .follow {
+    font-size: 10px;
   }
 
   .p_search_button,
@@ -17637,18 +17643,26 @@ button.toast-close-button {
 .follow_button:hover {
   background-color: #d0211c;
   border-color: #c51f1a;
+  font-size: 0;
 }
 
-button .unfollow_button {
-  display: none;
+.follow_button:hover:before {
+  font-size: 0.875rem;
+  content: "\30D5\30A9\30ED\30FC\89E3\9664";
 }
 
-button:hover .follow_now_button {
-  display: none;
+.follow_button:not(:disabled):not(.disabled):active,
+.follow_button:not(:disabled):not(.disabled).active,
+.show > .follow_button.dropdown-toggle {
+  color: #fff;
+  background-color: #c51f1a;
+  border-color: #b91d19;
 }
 
-button:hover .unfollow_button {
-  display: inline;
+.follow_button:not(:disabled):not(.disabled):active:focus,
+.follow_button:not(:disabled):not(.disabled).active:focus,
+.show > .follow_button.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(231, 82, 78, 0.5);
 }
 
 .like_now_icon {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48205,7 +48205,9 @@ $(function () {
   //いいね登録・解除処理
   $(document).on('click', '.like_button', function () {
     //全体ではなくクリックされた要素のみ指定
-    var $this = $(this); //投稿id(文字列のみ)を取得
+    var $this = $(this); //現在のファイルパスを取得
+
+    var url = location.pathname; //投稿id(文字列のみ)を取得
 
     var post_id = $this.attr('data-id');
     $.ajax({
@@ -48219,32 +48221,42 @@ $(function () {
         'id': post_id
       }
     }).done(function (data) {
-      //いいね登録成功時
+      var p_likes_path = '/posts/' + post_id + '/likes';
+      var u_likes_path = '/users/' + data['auth_id'] + '/likes'; //いいね登録成功時
+
       if (data['like'] === true) {
         toastr.success('投稿にいいねしました'); //アイコンの色変更(ピンク色へ)
 
         $this.attr('class', 'like_button btn btn like_now_icon fas fa-heart fa-lg');
-        $this.next('span').text(data['p_count']); //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+        $this.next('span').text(data['p_count']); //現在のURLが認証ユーザーの詳細ページだった場合(いいねページ)
+        //または投稿詳細ページ(いいねページ)
 
-        if ($('.p_count_badge').length) {
-          $('.p_count_badge').text(data['p_count']);
-        } //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
-        else if ($('.u_count_badge').length) {
-            $('.u_count_badge').text(data['u_count']);
-          }
-      } //いいね解除成功時
-      else if (data['unlike'] === false) {
-          toastr.success('投稿のいいねを外しました'); //アイコンの色変更(白色へ)
-
-          $this.attr('class', 'like_button btn btn like_icon far fa-heart fa-lg');
-          $this.next('span').text(data['p_count']); //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
-
+        if (url === p_likes_path || url === u_likes_path) {
+          //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
           if ($('.p_count_badge').length) {
             $('.p_count_badge').text(data['p_count']);
           } //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
           else if ($('.u_count_badge').length) {
               $('.u_count_badge').text(data['u_count']);
             }
+        }
+      } //いいね解除成功時
+      else if (data['unlike'] === false) {
+          toastr.success('投稿のいいねを外しました'); //アイコンの色変更(白色へ)
+
+          $this.attr('class', 'like_button btn btn like_icon far fa-heart fa-lg');
+          $this.next('span').text(data['p_count']); //現在のURLが認証ユーザーの詳細ページだった場合(いいねページ)
+          //または投稿詳細ページ(いいねページ)
+
+          if (url === p_likes_path || url === u_likes_path) {
+            //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+            if ($('.p_count_badge').length) {
+              $('.p_count_badge').text(data['p_count']);
+            } //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+            else if ($('.u_count_badge').length) {
+                $('.u_count_badge').text(data['u_count']);
+              }
+          }
         }
     }).fail(function (data) {
       toastr.error('失敗しました');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48004,6 +48004,8 @@ __webpack_require__(/*! ./dialog */ "./resources/js/dialog.js");
 
 __webpack_require__(/*! ./like_button */ "./resources/js/like_button.js");
 
+__webpack_require__(/*! ./follow_button */ "./resources/js/follow_button.js");
+
 /***/ }),
 
 /***/ "./resources/js/bootstrap.js":
@@ -48077,6 +48079,80 @@ $(function () {
     } else {
       return false;
     }
+  });
+});
+
+/***/ }),
+
+/***/ "./resources/js/follow_button.js":
+/*!***************************************!*\
+  !*** ./resources/js/follow_button.js ***!
+  \***************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+var $ = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js");
+
+var toastr = __webpack_require__(/*! toastr */ "./node_modules/toastr/toastr.js");
+
+$(function () {
+  //いいね登録・解除処理
+  $(document).on('click', '.follow', function () {
+    //全体ではなくクリックされた要素のみ指定
+    var $this = $(this); //現在のファイルパスを取得
+
+    var url = location.pathname; //投稿id(文字列のみ)を取得
+
+    var user_id = $this.attr('data-id');
+    $.ajax({
+      headers: {
+        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+      },
+      url: '/users/' + user_id + '/follow',
+      type: 'POST',
+      dataType: 'json',
+      data: {
+        'id': user_id
+      }
+    }).done(function (data) {
+      var following_path = '/users/' + data['auth_id'] + '/following';
+      var follower_path = '/users/' + data['auth_id'] + '/follower'; //フォロー成功時
+
+      if (data['follow'] === true) {
+        toastr.success('フォローしました'); //ボタン変更
+
+        $this.attr('class', 'follow btn btn-primary btn-sm rounded-pill follow_button');
+        $this.text('フォロー中'); //現在のURLが認証ユーザーの詳細ページだった場合(フォロー・フォロワーページ)
+
+        if (url === following_path || url === follower_path) {
+          //投稿詳細ページのナビゲーションタブのフォローカウントがコンテンツに含まれていた場合
+          if ($('.follow_count_badge').length) {
+            $('.follow_count_badge').text(data['follow_count']);
+          } //ユーザー詳細ページのナビゲーションタブのフォロワーカウントがコンテンツに含まれていた場合
+          else if ($('.follower_count_badge').length) {
+              $('.follower_count_badge').text(data['follower_count']);
+            }
+        }
+      } //アンフォロー成功時
+      else if (data['unfollow'] === false) {
+          toastr.success('フォローを外しました'); //ボタン変更
+
+          $this.attr('class', 'follow btn btn-outline-primary btn-sm rounded-pill');
+          $this.text('フォロー'); //現在のURLが認証ユーザーの詳細ページだった場合(フォロー・フォロワーページ)
+
+          if (url === following_path || url === follower_path) {
+            //ユーザー詳細ページのナビゲーションタブのフォローカウントがコンテンツに含まれていた場合
+            if ($('.follow_count_badge').length) {
+              $('.follow_count_badge').text(data['follow_count']);
+            } //ユーザー詳細ページのナビゲーションタブのフォロワーカウントがコンテンツに含まれていた場合
+            else if ($('.follower_count_badge').length) {
+                $('.follower_count_badge').text(data['follower_count']);
+              }
+          }
+        }
+    }).fail(function (data) {
+      toastr.error('失敗しました');
+    });
   });
 });
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=0ff5f327a41b4db07021",
+    "/js/app.js": "/js/app.js?id=3ed7685ab78e505d5264",
     "/css/app.css": "/css/app.css?id=7ee0db75751f54ebed05"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=1ca5b806a79dc43c67fb",
-    "/css/app.css": "/css/app.css?id=718212d7927b009901fb"
+    "/js/app.js": "/js/app.js?id=0ff5f327a41b4db07021",
+    "/css/app.css": "/css/app.css?id=7ee0db75751f54ebed05"
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,3 +7,4 @@ require('./reset_button');
 require('./toastr');
 require('./dialog');
 require('./like_button');
+require('./follow_button');

--- a/resources/js/follow_button.js
+++ b/resources/js/follow_button.js
@@ -1,0 +1,80 @@
+var $ = require('jquery');
+var toastr = require('toastr');
+
+$(function() {
+
+    //いいね登録・解除処理
+    $(document).on('click', '.follow', function() {
+
+        //全体ではなくクリックされた要素のみ指定
+        var $this = $(this);
+
+        //現在のファイルパスを取得
+        var url = location.pathname;
+
+        //投稿id(文字列のみ)を取得
+        var user_id = $this.attr('data-id');
+        $.ajax({
+            headers: {
+                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+            },
+            url: '/users/' + user_id + '/follow',
+            type: 'POST',
+            dataType: 'json',
+            data: {'id': user_id},
+        })
+        .done(function(data) {
+            var following_path = '/users/' + data['auth_id'] + '/following';
+            var follower_path = '/users/' + data['auth_id'] + '/follower';
+
+            //フォロー成功時
+            if (data['follow'] === true) {
+                toastr.success('フォローしました');
+
+                //ボタン変更
+                $this.attr('class', 'follow btn btn-primary btn-sm rounded-pill follow_button');
+                $this.text('フォロー中');
+
+                //現在のURLが認証ユーザーの詳細ページだった場合(フォロー・フォロワーページ)
+                if (url === following_path || url === follower_path) {
+
+                    //投稿詳細ページのナビゲーションタブのフォローカウントがコンテンツに含まれていた場合
+                    if ($('.follow_count_badge').length) {
+                        $('.follow_count_badge').text(data['follow_count']);
+                    }
+
+                    //ユーザー詳細ページのナビゲーションタブのフォロワーカウントがコンテンツに含まれていた場合
+                    else if ($('.follower_count_badge').length) {
+                        $('.follower_count_badge').text(data['follower_count']);
+                    }
+                }
+            }
+
+            //アンフォロー成功時
+            else if (data['unfollow'] === false) {
+                toastr.success('フォローを外しました');
+
+                //ボタン変更
+                $this.attr('class', 'follow btn btn-outline-primary btn-sm rounded-pill');
+                $this.text('フォロー');
+
+                //現在のURLが認証ユーザーの詳細ページだった場合(フォロー・フォロワーページ)
+                if (url === following_path || url === follower_path) {
+
+                    //ユーザー詳細ページのナビゲーションタブのフォローカウントがコンテンツに含まれていた場合
+                    if ($('.follow_count_badge').length) {
+                        $('.follow_count_badge').text(data['follow_count']);
+                    }
+
+                    //ユーザー詳細ページのナビゲーションタブのフォロワーカウントがコンテンツに含まれていた場合
+                    else if ($('.follower_count_badge').length) {
+                        $('.follower_count_badge').text(data['follower_count']);
+                    }
+                }
+            }
+        })
+        .fail(function(data) {
+            toastr.error('失敗しました');
+        });
+    });
+});

--- a/resources/js/like_button.js
+++ b/resources/js/like_button.js
@@ -9,6 +9,9 @@ $(function() {
         //全体ではなくクリックされた要素のみ指定
         var $this = $(this);
 
+        //現在のファイルパスを取得
+        var url = location.pathname;
+
         //投稿id(文字列のみ)を取得
         var post_id = $this.attr('data-id');
         $.ajax({
@@ -21,6 +24,8 @@ $(function() {
             data: {'id': post_id},
         })
         .done(function(data) {
+            var p_likes_path = '/posts/' + post_id + '/likes';
+            var u_likes_path = '/users/' + data['auth_id'] + '/likes';
 
             //いいね登録成功時
             if (data['like'] === true) {
@@ -30,14 +35,19 @@ $(function() {
                 $this.attr('class', 'like_button btn btn like_now_icon fas fa-heart fa-lg');
                 $this.next('span').text(data['p_count']);
 
-                //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
-                if ($('.p_count_badge').length) {
-                    $('.p_count_badge').text(data['p_count']);
-                }
+                //現在のURLが認証ユーザーの詳細ページだった場合(いいねページ)
+                //または投稿詳細ページ(いいねページ)
+                if (url === p_likes_path || url === u_likes_path) {
 
-                //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
-                else if ($('.u_count_badge').length) {
-                    $('.u_count_badge').text(data['u_count']);
+                    //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+                    if ($('.p_count_badge').length) {
+                        $('.p_count_badge').text(data['p_count']);
+                    }
+    
+                    //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+                    else if ($('.u_count_badge').length) {
+                        $('.u_count_badge').text(data['u_count']);
+                    }
                 }
             }
 
@@ -49,14 +59,19 @@ $(function() {
                 $this.attr('class', 'like_button btn btn like_icon far fa-heart fa-lg');
                 $this.next('span').text(data['p_count']);
 
-                //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
-                if ($('.p_count_badge').length) {
-                    $('.p_count_badge').text(data['p_count']);
-                }
+                //現在のURLが認証ユーザーの詳細ページだった場合(いいねページ)
+                //または投稿詳細ページ(いいねページ)
+                if (url === p_likes_path || url === u_likes_path) {
 
-                //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
-                else if ($('.u_count_badge').length) {
-                    $('.u_count_badge').text(data['u_count']);
+                    //投稿詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+                    if ($('.p_count_badge').length) {
+                        $('.p_count_badge').text(data['p_count']);
+                    }
+    
+                    //ユーザー詳細ページのナビゲーションタブのいいねカウントがコンテンツに含まれていた場合
+                    else if ($('.u_count_badge').length) {
+                        $('.u_count_badge').text(data['u_count']);
+                    }
                 }
             }
         })

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -21,13 +21,22 @@
 
 @media (max-width: 315px) {
 
-  .follow_button,
-  .action_follow {
-    font-size: 10px;
+  //ホバー時フォロー中ボタンの色変更
+  .follow_button:hover {
+    background-color: #d0211c;
+    border-color: #c51f1a;
+    font-size: 0 !important;
+  }
+  
+  //ホバー時のフォロー中ボタンテキスト変更
+  .follow_button:hover:before {
+    font-size: 10px !important;
+    content: "フォロー解除" !important;
   }
 
-  .unfollow_button {
-    font-size: 9px;
+  //フォロー・フォロー中ボタン
+  .follow {
+    font-size: 10px;
   }
 
   //投稿検索ボタン・リセットボタン
@@ -398,21 +407,29 @@
 .follow_button:hover {
   background-color: #d0211c;
   border-color: #c51f1a;
+  font-size: 0;
 }
 
-//ホバー時のアンフォローボタン文字(通常は非表示)
-button .unfollow_button {
-  display: none;
+//ホバー時のフォロー中ボタンテキスト変更
+.follow_button:hover:before {
+  font-size: 0.875rem;
+  content: "フォロー解除";
 }
 
-//ホバー時は通常フォロー中のボタン文字を非表示
-button:hover .follow_now_button {
-  display: none;
+//active時のフォロー中ボタン色変更
+.follow_button:not(:disabled):not(.disabled):active,
+.follow_button:not(:disabled):not(.disabled).active,
+.show > .follow_button.dropdown-toggle {
+  color: #fff;
+  background-color: #c51f1a;
+  border-color: #b91d19;
 }
 
-//ホバー時のアンフォローボタン文字の表示
-button:hover .unfollow_button {
-  display: inline;
+//activrefocus時のフォロー中ボタンボーダー色変更
+.follow_button:not(:disabled):not(.disabled):active:focus,
+.follow_button:not(:disabled):not(.disabled).active:focus,
+.show > .follow_button.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(231, 82, 78, 0.5);
 }
 
 //平常時のいいね中ボタンのスタイル

--- a/resources/views/commons/navtabs_user_show.blade.php
+++ b/resources/views/commons/navtabs_user_show.blade.php
@@ -10,14 +10,14 @@
     <li class="nav-item">
         <a href="{{ route('users.followings', ['id' => $user->id]) }}" class="nav-link {{ Request::routeIs('users.followings') ? 'active' : '' }} text-dark">
             フォロー
-            <span class="badge badge-white badge-pill">{{ $user->followings_count }}</span>
+            <span class="badge badge-white badge-pill follow_count_badge">{{ $user->followings_count }}</span>
         </a>
     </li>
     {{-- フォロワー一覧タブ --}}
     <li class="nav-item">
         <a href="{{ route('users.followers', ['id' => $user->id]) }}" class="nav-link {{ Request::routeIs('users.followers') ? 'active' : '' }} text-dark">
             フォロワー
-            <span class="badge badge-white badge-pill">{{ $user->followers_count }}</span>
+            <span class="badge badge-white badge-pill follower_count_badge">{{ $user->followers_count }}</span>
         </a>
     </li>
     {{-- いいえね一覧タブ --}}

--- a/resources/views/user_follow/follow_button.blade.php
+++ b/resources/views/user_follow/follow_button.blade.php
@@ -2,17 +2,18 @@
     @if(Auth::id() != $user->id)
         @if(Auth::user()->isFollowing($user->id))
             {{-- アンフォローボタン --}}
-            <form method="POST" action="{{ route('user.unfollow', $user->id) }}">
-                @method('DELETE')
-                @csrf
-                <button type="submit" class="btn btn-primary btn-sm rounded-pill follow_button"><span class="unfollow_button">フォロー解除</span><span class="follow_now_button">フォロー中</span></button>
-            </form>
+            <div>
+                <button type="button" class="follow btn btn-primary btn-sm rounded-pill follow_button" data-id="{{ $user->id }}">
+                    フォロー中
+                </button>
+            </div>
         @else
             {{-- フォローボタン --}}
-            <form method="POST" action="{{ route('user.follow', $user->id) }}">
-                @csrf
-                <button type="submit" class="btn btn-outline-primary btn-sm rounded-pill action_follow">フォロー</button>
-            </form>
+            <div>
+                <button type="button" class="follow btn btn-outline-primary btn-sm rounded-pill" data-id="{{ $user->id }}">
+                    フォロー
+                </button>
+            </div>
         @endif
     @endif
 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Auth::routes();
 Route::group(['prefix' => 'users/{id}'], function() {
     Route::get('following', 'UsersController@followings')->name('users.followings');
     Route::get('follower', 'UsersController@followers')->name('users.followers');
-    Route::get('like', 'UsersController@likes')->name('users.likes');
+    Route::get('likes', 'UsersController@likes')->name('users.likes');
 });
 
 //登録ユーザー詳細ページ

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,10 +39,7 @@ Route::resource('users', 'UsersController', ['only' => ['index', 'show']]);
 Route::group(['middleware' => ['auth']], function() {
 
     //フォロー・アンフォロー
-    Route::group(['prefix' => 'users/{id}'], function() {
-        Route::post('follow', 'UserFollowController@store')->name('user.follow');
-        Route::delete('unfollow', 'UserFollowController@destroy')->name('user.unfollow');
-    });
+    Route::post('users/{id}/follow', 'UserFollowController@store')->name('user.follow');
 
     //ユーザー編集
     Route::resource('users', 'UsersController', ['only' => ['edit', 'update']]);


### PR DESCRIPTION
関連issue #48 

**変更点など**
- フォロー登録・解除リクエストを同期通信→非同期通信へ変更
- ナビゲーションタブのいいねカウントの修正