### PR TITLE
コメント機能同期➞非同期へ変更

### DIFF
--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\CommentRequest;
+use Illuminate\Http\Request;
 use App\Post;
 use App\Comment;
 
@@ -11,34 +12,74 @@ class CommentsController extends Controller
     //認証ユーザーからの、投稿コメントリクエスト
     public function store(CommentRequest $request)
     {
-        if (\Auth::check()) {
-            $user = auth()->user();
+        $user = auth()->user();
 
-            //Commentモデルにリクエストを保存
-            $user->userComments()->create([
-                    'post_id' => $request->post_id,
-                    'comment' => $request->comment,
-                ]);
-            return back()->with('msg_success', '投稿にコメントしました');
-        }
-        else {
-            return back()->with('msg_error', 'ログインしてください');
-        }
+        $post_id = $request->post_id;
+        $comment = $request->comment;
+
+        //Commentモデルにリクエストを保存
+        $user->userComments()->create([
+                'post_id' => $post_id,
+                'comment' => $comment,
+            ]);
+
+        //投稿のコメントを取得
+        $comments = Post::findOrFail($post_id)->postComments();
+
+        //最新のコメント一件を取得
+        $comment = $comments
+                    ->with('user')
+                    ->orderBy('created_at', 'desc')
+                    ->first();
+
+        //コメントのカウントを取得
+        $comment_count = $comments
+                        ->count();
+
+        return response()->json([
+                    'comment' => $comment,
+                    'comment_count' => $comment_count,
+                    ]);
     }
 
     //コメント所有ユーザーからの、コメント削除リクエスト
-    public function destroy($id)
+    public function destroy(Request $request)
     {
+        $comment_id = $request->comment_id;
+        $comment_length = $request->comment_length;
+        $post_id = $request->post_id;
+
         //コメントをidから特定
-        $comment = Comment::findOrFail($id);
+        $select_comment = Comment::findOrFail($comment_id);
+        $auth_id = \Auth::id();
 
         //認証ユーザーidとコメントユーザーidを比較
-        if (\Auth::id() === $comment->user_id) {
-            $comment->delete();
-            return back()->with('msg_success', 'コメントを削除しました');
+        if ($auth_id === $select_comment->user_id) {
+
+            //コメント削除
+            $select_comment->delete();
+
+            //投稿のコメントを取得
+            $comment = Post::findOrFail($post_id)
+                        ->postComments()
+                        ->with('user')
+                        ->orderBy('created_at', 'desc')
+                        ->skip($comment_length - 1)
+                        ->first();
+
+            //コメントカウント取得
+            $comment_count = $select_comment->post->postComments->count();
+
+            return response()->json([
+                    'comment' => $comment,
+                    'auth_id' => $auth_id,
+                    'comment_count' => $comment_count,
+                    ]);
         }
         else {
-            return back()->with('msg_error', 'コメントを削除できません');;
+            return response()->json([
+                        'message' => 'コメントを削除できません',
+                    ]);
         }
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -96,7 +96,7 @@ class PostsController extends Controller
         $post_images = $post->postImages;
         $post_categorys = $post->postCategorys;
         $post->loadRelationshipCounts();
-        $comments = $post->postComments()->orderBy('created_at', 'desc')->simplePaginate(12);
+        $comments = $post->postComments()->orderBy('created_at', 'desc')->simplePaginate(11);
 
         return view('posts.show',[
             'post' => $post,

--- a/app/Http/Requests/CommentRequest.php
+++ b/app/Http/Requests/CommentRequest.php
@@ -32,13 +32,27 @@ class CommentRequest extends FormRequest
         ];
     }
 
-    //フラッシュメッセージのみ追加し、オーバーライド
+    public function messages()
+    {
+        return [
+            'post_id.required' => '投稿IDを入力してください',
+            'post_id.exists' => '投稿IDがデータベースに存在しません',
+            'comment.required' => 'コメントを入力してください',
+            'comment.max' => 'コメントは150字以下で入力してください',
+            'comment.string' => 'コメントは文字列で入力してください',
+        ];
+    }
+
+    //json形式でエラー情報を返す
     protected function failedValidation(Validator $validator)
     {
-        $this->merge(['validated' => 'true']);
-        // リダイレクト先
+        $response['data'] = [];
+        $response['status'] = 'NG';
+        $response['summary'] = 'Failed validation';
+        $response['errors'] = $validator->errors()->toArray();
+
         throw new HttpResponseException(
-        back()->withInput($this->input)->withErrors($validator)->with('msg_error', 'コメント投稿に失敗しました')
-        );
+                response()->json($response, 422)
+            );
     }
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17774,10 +17774,12 @@ textarea {
   position: relative;
   margin: 0 0 0 20px;
   padding: 8px;
+  min-width: 30px;
   border-radius: 12px;
   background: #edf1ee;
   font-size: 1rem;
   text-align: left;
+  word-break: break-all;
 }
 
 .authenticated_user_comment {
@@ -17799,10 +17801,12 @@ textarea {
   position: relative;
   margin: 0 20px 0 0;
   padding: 8px;
+  min-width: 30px;
   border-radius: 12px;
   background: #7ed957;
   font-size: 1rem;
   text-align: left;
+  word-break: break-all;
 }
 
 .p_category {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48008,6 +48008,12 @@ __webpack_require__(/*! ./follow_button */ "./resources/js/follow_button.js");
 
 __webpack_require__(/*! ./smooth_scroll */ "./resources/js/smooth_scroll.js");
 
+__webpack_require__(/*! ./comment */ "./resources/js/comment.js");
+
+__webpack_require__(/*! ./format_date */ "./resources/js/format_date.js");
+
+__webpack_require__(/*! ./nl2br */ "./resources/js/nl2br.js");
+
 /***/ }),
 
 /***/ "./resources/js/bootstrap.js":
@@ -48055,27 +48061,273 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /***/ }),
 
+/***/ "./resources/js/comment.js":
+/*!*********************************!*\
+  !*** ./resources/js/comment.js ***!
+  \*********************************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _format_date__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./format_date */ "./resources/js/format_date.js");
+/* harmony import */ var _nl2br__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./nl2br */ "./resources/js/nl2br.js");
+/* harmony import */ var _dialog__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./dialog */ "./resources/js/dialog.js");
+var $ = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js");
+
+
+
+
+
+var toastr = __webpack_require__(/*! toastr */ "./node_modules/toastr/toastr.js");
+
+$(function () {
+  //新規コメント投稿
+  $(document).on('click', '.comment_button', function () {
+    //フォームの値を取得
+    var comment = $('#comment').val();
+    var post_id = $('#post_id').val(); //コメントが未入力なら処理終了
+
+    if (comment === "") {
+      toastr.error('コメントが未入力です');
+      return false;
+    } //コメント入力値があれば
+    else {
+        $.ajax({
+          headers: {
+            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+          },
+          url: '/comments',
+          type: 'POST',
+          dataType: 'json',
+          data: {
+            'post_id': post_id,
+            'comment': comment
+          }
+        }).done(function (data) {
+          //成功フラッシュメッセージを表示
+          toastr.success('コメント投稿しました'); //入力値をクリア
+
+          $('#comment').val(''); //コメントがない場合の表示があればそれを消去
+
+          if ($('.no_comment').length) {
+            $('.no_comment').remove();
+          } //ナビゲーションタブのコメントカウント
+
+
+          if ($('.p_comment_count_badge').length) {
+            $('.p_comment_count_badge').text(data['comment_count']);
+          } //バリデーションのクラスがあればクラス名を削除
+
+
+          if ($('.is-invalid').length) {
+            $('#comment').removeClass('is-invalid');
+          }
+
+          var html = ''; //ユーザーのアバター画像がnullの場合は、こちらの画像を使用
+
+          var img_src = "/storage/images/default_icon.png"; //コメントしたユーザーの情報
+
+          var user_id = data['comment']['user']['id'];
+          var name = data['comment']['user']['name'];
+          var avatar = data['comment']['user']['avatar']; //コメントの情報
+
+          var comment_id = data['comment']['id'];
+          var comment = Object(_nl2br__WEBPACK_IMPORTED_MODULE_1__["nl2br"])(data['comment']['comment']); //nl2br関数の使用
+
+          var created_at = Object(_format_date__WEBPACK_IMPORTED_MODULE_0__["formatDate"])(new Date(data['comment']['created_at']), 'YYYY/MM/DD hh:mm'); //formatDate関数の使用
+          //アバター画像がnullならば
+
+          if (!avatar) {
+            html = "\n                            <div class=\"balloon overflow-hidden my-2 w-100\" data-comment-id=\"".concat(comment_id, "\">\n                                <div class=\"balloon_chatting w-100 text-right\">\n                                    <a href=\"/users/").concat(user_id, "\" class=\"text-dark mr-auto font-weight-bold\"><div class=\"card-title\">").concat(name, "<img src=\"").concat(img_src, "\" class=\"rounded-circle ml-1\" width=\"40\" height=\"40\" alt=\"").concat(name, "\u306E\u30A2\u30D0\u30BF\u30FC\u753B\u50CF\u3002\u8A73\u7D30\u307A\u30FC\u30B8\u3078\u306E\u30EA\u30F3\u30AF\"></div></a>\n                                    <div class=\"authenticated_user_comment\">\n                                        <p>").concat(comment, "</p>\n                                    </div>\n                                    <div class=\"mb-2\">\n                                        <small>").concat(created_at, "</small>\n                                        <button type=\"button\" class=\"btn btn-link comment_trash text-danger comment_delete\" data-id=\"").concat(comment_id, "\"><i class=\"far fa-trash-alt\"></i>\u524A\u9664</button>\n                                    </div>\n                                </div>\n                            </div>\n                        ");
+          } //アバター画像があれば
+          else {
+              html = "\n                            <div class=\"balloon overflow-hidden my-2 w-100\" data-comment-id=\"".concat(comment_id, "\">\n                                <div class=\"balloon_chatting w-100 text-right\">\n                                    <a href=\"/users/").concat(user_id, "\" class=\"text-dark mr-auto font-weight-bold\"><div class=\"card-title\">").concat(name, "<img src=\"").concat(avatar, "\" class=\"rounded-circle ml-1\" width=\"40\" height=\"40\" alt=\"").concat(name, "\u306E\u30A2\u30D0\u30BF\u30FC\u753B\u50CF\u3002\u8A73\u7D30\u307A\u30FC\u30B8\u3078\u306E\u30EA\u30F3\u30AF\"></div></a>\n                                    <div class=\"authenticated_user_comment\">\n                                        <p>").concat(comment, "</p>\n                                    </div>\n                                    <div class=\"mb-2\">\n                                        <small>").concat(created_at, "</small>\n                                        <button type=\"button\" class=\"btn btn-link comment_trash text-danger comment_delete\" data-id=\"").concat(comment_id, "\"><i class=\"far fa-trash-alt\"></i>\u524A\u9664</button>\n                                    </div>\n                                </div>\n                            </div>\n                            ");
+            } //コメントエリアに先頭にコメントを追加
+
+
+          $('#comment_area').prepend(html); //一番最後のページのコメントを取得したらここの処理は入らない
+
+          if ($('.balloon').length !== data['comment_count']) {
+            //各ページの最後のコメントをコメントが投稿されるたびにコンテンツから削除
+            //次ページを読みこんだ際重複するため(1ページ11コメント)
+            if ($('.balloon').length % 11 === 1) {
+              $('#comment_area .balloon:last').detach();
+            }
+          }
+        }).fail(function (jqXHR, textStatus, errorThrown) {
+          //もし前のバリデーションエラーメッセージが残っていれば
+          //メッセージを削除
+          if ($('.invalid-feedback').length) {
+            $('.invalid-feedback').remove();
+          } //失敗フラッシュメッセージを表示
+
+
+          toastr.error('コメント投稿に失敗しました');
+          var text = $.parseJSON(jqXHR.responseText); //バリデーションエラーメッセージ取得
+
+          var errors = text.errors;
+
+          for (var key in errors) {
+            //繰り返してメッセージをコードに挿入
+            var errorMessage = errors[key][0];
+            var error_html = "\n                                        <span class=\"invalid-feedback\" role=\"alert\">\n                                            <strong>".concat(errorMessage, "</strong>\n                                        </span>\n                                    "); //失敗したことを明示するスタイルを追加
+            //エラーメッセージを追加
+
+            $('#comment').addClass('is-invalid');
+            $('#comment_msg_error').append(error_html);
+          }
+        });
+      }
+  }); //コメント削除
+
+  $(document).on('click', '.comment_delete', function () {
+    var $this = $(this); //ダイアログでokが押された場合コメント削除処理に入る
+
+    if (Object(_dialog__WEBPACK_IMPORTED_MODULE_2__["comment_delete_dialog"])(true)) {
+      //二重送信防止用のスタイルを追加
+      $this.css('pointer-events', 'none'); //コメントidを取得
+
+      var d_comment_id = $this.attr('data-id'); //投稿idを取得
+
+      var post_id = $('#post_id').val(); //コメントの要素数を取得
+
+      var comment_length = $('.balloon').length;
+      $.ajax({
+        headers: {
+          'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+        },
+        url: '/comments/' + d_comment_id,
+        type: 'POST',
+        dataType: 'json',
+        data: {
+          'comment_id': d_comment_id,
+          'comment_length': comment_length,
+          'post_id': post_id,
+          '_method': 'DELETE'
+        }
+      }).done(function (data) {
+        var html = ''; //コメントの所有者ではなかったらメッセージを表示して処理終了
+
+        if (data['message']) {
+          toastr.error(data['message']);
+          return false;
+        } //成功フラッシュメッセージを表示
+
+
+        toastr.success('コメントを削除しました'); //バリデーションエラー明示中であれば一旦バリデーションエラークラス属性を削除
+
+        if ($('.is-invalid').length) {
+          $('#comment').removeClass('is-invalid');
+        } //ナビゲーションタブのコメントカウント
+
+
+        if ($('.p_comment_count_badge').length) {
+          $('.p_comment_count_badge').text(data['comment_count']);
+        } //削除されたコメントをフロント側でも削除
+
+
+        $this.parents('.balloon').remove(); //コメントが0になったらコメントが無い時の表示にし処理終了
+
+        if (data['comment_count'] === 0) {
+          var _html = "\n                                <div class=\"d-flex justify-content-center align-items-center no_comment\" style=\"font-size:16px; height:200px; color:rgba(0,0,0,0.4);\">\n                                    \u307E\u3060\u30B3\u30E1\u30F3\u30C8\u304C\u3042\u308A\u307E\u305B\u3093\n                                </div>\n                                ";
+          $('#comment_area').append(_html); //二重送信防止用のスタイル解除
+
+          $this.css('pointer-events', '');
+          return false;
+        }
+        /*
+            ここからはコメントを削除した際に出る
+            次ページとのコメント差分をエリアに追加する処理
+        */
+        //ページが最後であればここの処理は入らない
+
+
+        if ($('.balloon').length !== data['comment_count']) {
+          //認証ユーザーID取得
+          var auth_id = data['auth_id']; //ユーザーのアバター画像がnullの場合は、こちらの画像を使用
+
+          var img_src = "/storage/images/default_icon.png"; //コメントしたユーザーの情報
+
+          var user_id = data['comment']['user']['id'];
+          var name = data['comment']['user']['name'];
+          var avatar = data['comment']['user']['avatar']; //コメントの情報
+
+          var comment_id = data['comment']['id'];
+          var comment = Object(_nl2br__WEBPACK_IMPORTED_MODULE_1__["nl2br"])(data['comment']['comment']); //nl2br関数の使用
+
+          var created_at = Object(_format_date__WEBPACK_IMPORTED_MODULE_0__["formatDate"])(new Date(data['comment']['created_at']), 'YYYY/MM/DD hh:mm'); //formatDate関数の使用
+          //認証ユーザーコメントならばこちらのコード生成
+
+          if (auth_id === user_id) {
+            //アバター画像がnullならば
+            if (!avatar) {
+              html = "\n                                    <div class=\"balloon overflow-hidden my-2 w-100\" data-comment-id=\"".concat(comment_id, "\">\n                                        <div class=\"balloon_chatting w-100 text-right\">\n                                            <a href=\"/users/").concat(user_id, "\" class=\"text-dark mr-auto font-weight-bold\"><div class=\"card-title\">").concat(name, "<img src=\"").concat(img_src, "\" class=\"rounded-circle ml-1\" width=\"40\" height=\"40\" alt=\"").concat(name, "\u306E\u30A2\u30D0\u30BF\u30FC\u753B\u50CF\u3002\u8A73\u7D30\u307A\u30FC\u30B8\u3078\u306E\u30EA\u30F3\u30AF\"></div></a>\n                                            <div class=\"authenticated_user_comment\">\n                                                <p>").concat(comment, "</p>\n                                            </div>\n                                            <div class=\"mb-2\">\n                                                <small>").concat(created_at, "</small>\n                                                <button type=\"button\" class=\"btn btn-link comment_trash text-danger comment_delete\" data-id=\"").concat(comment_id, "\"><i class=\"far fa-trash-alt\"></i>\u524A\u9664</button>\n                                            </div>\n                                        </div>\n                                    </div>\n                                ");
+            } //アバター画像があれば
+            else {
+                html = "\n                                    <div class=\"balloon overflow-hidden my-2 w-100\" data-comment-id=\"".concat(comment_id, "\">\n                                        <div class=\"balloon_chatting w-100 text-right\">\n                                            <a href=\"/users/").concat(user_id, "\" class=\"text-dark mr-auto font-weight-bold\"><div class=\"card-title\">").concat(name, "<img src=\"").concat(avatar, "\" class=\"rounded-circle ml-1\" width=\"40\" height=\"40\" alt=\"").concat(name, "\u306E\u30A2\u30D0\u30BF\u30FC\u753B\u50CF\u3002\u8A73\u7D30\u307A\u30FC\u30B8\u3078\u306E\u30EA\u30F3\u30AF\"></div></a>\n                                            <div class=\"authenticated_user_comment\">\n                                                <p>").concat(comment, "</p>\n                                            </div>\n                                            <div class=\"mb-2\">\n                                                <small>").concat(created_at, "</small>\n                                                <button type=\"button\" class=\"btn btn-link comment_trash text-danger comment_delete\" data-id=\"").concat(comment_id, "\"><i class=\"far fa-trash-alt\"></i>\u524A\u9664</button>\n                                            </div>\n                                        </div>\n                                    </div>\n                                    ");
+              }
+          } //認証ユーザー以外のコメントならばこちらのコード生成
+          else {
+              //アバター画像がnullならば
+              if (!avatar) {
+                html = "\n                                    <div class=\"balloon overflow-hidden my-2 w-100\" data-comment-id=\"".concat(comment_id, "\">\n                                        <div class=\"balloon_chatting overflow-hidden w-100 text-left\">\n                                            <a href=\"/users/").concat(user_id, "\" class=\"text-dark mr-auto font-weight-bold\"><div class=\"card-title\"><img src=\"").concat(img_src, "\" class=\"rounded-circle mr-1\" width=\"40\" height=\"40\" alt=\"").concat(name, "\u306E\u30A2\u30D0\u30BF\u30FC\u753B\u50CF\u3002\u8A73\u7D30\u307A\u30FC\u30B8\u3078\u306E\u30EA\u30F3\u30AF\">").concat(name, "</div></a>\n                                            <div class=\"user_comment\">\n                                                <p>").concat(comment, "</p>\n                                            </div>\n                                            <div class=\"mb-4 ml-4\">\n                                                <small>").concat(created_at, "</small>\n                                            </div>\n                                        </div>\n                                    </div>\n                                    ");
+              } //アバター画像があれば
+              else {
+                  html = "\n                                    <div class=\"balloon overflow-hidden my-2 w-100\" data-comment-id=\"".concat(comment_id, "\">\n                                        <div class=\"balloon_chatting overflow-hidden w-100 text-left\">\n                                            <a href=\"/users/").concat(user_id, "\" class=\"text-dark mr-auto font-weight-bold\"><div class=\"card-title\"><img src=\"").concat(avatar, "\" class=\"rounded-circle mr-1\" width=\"40\" height=\"40\" alt=\"").concat(name, "\u306E\u30A2\u30D0\u30BF\u30FC\u753B\u50CF\u3002\u8A73\u7D30\u307A\u30FC\u30B8\u3078\u306E\u30EA\u30F3\u30AF\">").concat(name, "</div></a>\n                                            <div class=\"user_comment\">\n                                                <p>").concat(comment, "</p>\n                                            </div>\n                                            <div class=\"mb-4 ml-4\">\n                                                <small>").concat(created_at, "</small>\n                                            </div>\n                                        </div>\n                                    </div>\n                                    ");
+                }
+            } //次ページを読みこんだ際要素が消えているためこの条件式 (1ページ11コメント)
+
+
+          if ($('.balloon').length % 11 === 10) {
+            //コメントエリアの最後にコメントを追加
+            $('#comment_area').append(html);
+          } //二重送信防止用のスタイル解除
+
+
+          $this.css('pointer-events', '');
+        }
+        /*
+            ここまでがコメントの追加処理
+        */
+
+      }).fail(function (data) {
+        //失敗フラッシュメッセージを表示
+        toastr.error('コメント削除に失敗しました'); //二重送信防止用のスタイル解除
+
+        $this.css('pointer-events', '');
+      });
+    } //ダイアログのキャンセルを押したら処理終了
+    else {
+        return false;
+      }
+  });
+});
+
+/***/ }),
+
 /***/ "./resources/js/dialog.js":
 /*!********************************!*\
   !*** ./resources/js/dialog.js ***!
   \********************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/*! exports provided: comment_delete_dialog */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var $ = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js");
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "comment_delete_dialog", function() { return comment_delete_dialog; });
+var $ = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js"); //コメント削除ダイアログ
 
+
+function comment_delete_dialog() {
+  if (confirm('コメントを削除してよろしいですか？')) {
+    return true;
+  } else {
+    return false;
+  }
+}
 $(function () {
-  //コメント削除ダイヤログ
-  $(document).on('click', '.comment_delete_alert', function () {
-    var $this = $(this);
-
-    if (confirm('コメントを削除してよろしいですか？')) {
-      $this.submit();
-    } else {
-      return false;
-    }
-  }); //投稿削除ダイヤログ
-
+  //投稿削除ダイヤログ
   $(document).on('click', '.post_delete_alert', function () {
     var $this = $(this);
 
@@ -48192,6 +48444,35 @@ $(function () {
 
 /***/ }),
 
+/***/ "./resources/js/format_date.js":
+/*!*************************************!*\
+  !*** ./resources/js/format_date.js ***!
+  \*************************************/
+/*! exports provided: formatDate */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "formatDate", function() { return formatDate; });
+//データ年月日フォーマット関数
+function formatDate(date, format) {
+  // 年
+  format = format.replace(/YYYY/g, date.getFullYear()); //月
+
+  format = format.replace(/MM/g, ('0' + (date.getMonth() + 1)).slice(-2)); //日
+
+  format = format.replace(/DD/g, ('0' + date.getDate()).slice(-2)); //時
+
+  format = format.replace(/hh/g, ('0' + date.getHours()).slice(-2)); //分
+
+  format = format.replace(/mm/g, ('0' + date.getMinutes()).slice(-2)); //秒
+
+  format = format.replace(/ss/g, ('0' + date.getSeconds()).slice(-2));
+  return format;
+}
+
+/***/ }),
+
 /***/ "./resources/js/infinite_scroll.js":
 /*!*****************************************!*\
   !*** ./resources/js/infinite_scroll.js ***!
@@ -48199,27 +48480,36 @@ $(function () {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
+var $ = __webpack_require__(/*! jquery */ "./node_modules/jquery/dist/jquery.js");
+
+var jQueryBridget = __webpack_require__(/*! jquery-bridget */ "./node_modules/jquery-bridget/jquery-bridget.js");
+
 var InfiniteScroll = __webpack_require__(/*! infinite-scroll */ "./node_modules/infinite-scroll/js/index.js");
 
-var user_list = document.getElementById('user_list');
-var infScroll = new InfiniteScroll(user_list, {
-  path: '.pagination_next',
-  append: '.user_card',
-  history: false,
-  button: '.view_more_button',
-  scrollThreshold: false,
-  hideNav: '.pagination',
-  status: '.page_load_status'
-});
-var comment_area = document.getElementById('comment_area');
-var infScroll = new InfiniteScroll(comment_area, {
-  path: '.comment_next',
-  append: '.balloon',
-  history: false,
-  button: '.comment_more_button',
-  scrollThreshold: false,
-  hideNav: '.pagination',
-  status: '.page_load_status'
+jQueryBridget('infiniteScroll', InfiniteScroll, $); //ユーザー一覧、フォロー一覧、フォロワー一覧
+
+$(function () {
+  $('#user_list').infiniteScroll({
+    path: '.pagination_next',
+    append: '.user_card',
+    history: false,
+    button: '.view_more_button',
+    scrollThreshold: false,
+    hideNav: '.pagination',
+    status: '.page_load_status'
+  });
+}); //コメント一覧
+
+$(function () {
+  $('#comment_area').infiniteScroll({
+    path: '.comment_next',
+    append: '.balloon',
+    history: false,
+    //button: '.comment_more_button',
+    //scrollThreshold: false,
+    hideNav: '.pagination',
+    status: '.page_load_status'
+  });
 });
 
 /***/ }),
@@ -48299,6 +48589,26 @@ $(function () {
     });
   });
 });
+
+/***/ }),
+
+/***/ "./resources/js/nl2br.js":
+/*!*******************************!*\
+  !*** ./resources/js/nl2br.js ***!
+  \*******************************/
+/*! exports provided: nl2br */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "nl2br", function() { return nl2br; });
+//textarea等で作成保存したデータの表示
+//nl2br()の表示のような関数
+function nl2br(str) {
+  str = str.replace(/\r\n/g, "<br />");
+  str = str.replace(/(\n|\r)/g, "<br />");
+  return str;
+}
 
 /***/ }),
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=3843c3a22fc252531a4f",
-    "/css/app.css": "/css/app.css?id=c7074e8f9632921bb26e"
+    "/js/app.js": "/js/app.js?id=47e08acd193b4d6df7b6",
+    "/css/app.css": "/css/app.css?id=71b848ee122bee673c89"
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,3 +9,6 @@ require('./dialog');
 require('./like_button');
 require('./follow_button');
 require('./smooth_scroll');
+require('./comment');
+require('./format_date');
+require('./nl2br');

--- a/resources/js/comment.js
+++ b/resources/js/comment.js
@@ -1,0 +1,358 @@
+let $ = require('jquery');
+import {formatDate} from './format_date';
+import {nl2br} from './nl2br';
+import {comment_delete_dialog} from './dialog';
+let toastr = require('toastr');
+
+$(function() {
+
+    //新規コメント投稿
+    $(document).on('click', '.comment_button', function() {
+
+        //フォームの値を取得
+        let comment = $('#comment').val();
+        let post_id = $('#post_id').val();
+
+        //コメントが未入力なら処理終了
+        if (comment === "") {
+            toastr.error('コメントが未入力です');
+            return false;
+        }
+
+        //コメント入力値があれば
+        else {
+            $.ajax({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                },
+                url: '/comments',
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    'post_id': post_id, 
+                    'comment': comment
+                },
+            })
+            .done(function(data) {
+
+                //成功フラッシュメッセージを表示
+                toastr.success('コメント投稿しました');
+
+                //入力値をクリア
+                $('#comment').val('');
+
+                //コメントがない場合の表示があればそれを消去
+                if($('.no_comment').length) {
+                    $('.no_comment').remove();
+                }
+
+                //ナビゲーションタブのコメントカウント
+                if ($('.p_comment_count_badge').length) {
+                    $('.p_comment_count_badge').text(data['comment_count']);
+                }
+
+                //バリデーションのクラスがあればクラス名を削除
+                if ($('.is-invalid').length) {
+                    $('#comment').removeClass('is-invalid');
+                }
+
+                let html = '';
+
+                //ユーザーのアバター画像がnullの場合は、こちらの画像を使用
+                let img_src = "/storage/images/default_icon.png";
+
+                //コメントしたユーザーの情報
+                let user_id = data['comment']['user']['id'];
+                let name = data['comment']['user']['name'];
+                let avatar = data['comment']['user']['avatar'];
+
+                //コメントの情報
+                let comment_id = data['comment']['id'];
+                let comment = nl2br(data['comment']['comment']); //nl2br関数の使用
+                let created_at = formatDate(new Date(data['comment']['created_at']), 'YYYY/MM/DD hh:mm'); //formatDate関数の使用
+
+                //アバター画像がnullならば
+                if (!avatar) {
+                    html = `
+                            <div class="balloon overflow-hidden my-2 w-100" data-comment-id="${comment_id}">
+                                <div class="balloon_chatting w-100 text-right">
+                                    <a href="/users/${user_id}" class="text-dark mr-auto font-weight-bold"><div class="card-title">${name}<img src="${img_src}" class="rounded-circle ml-1" width="40" height="40" alt="${name}のアバター画像。詳細ぺージへのリンク"></div></a>
+                                    <div class="authenticated_user_comment">
+                                        <p>${comment}</p>
+                                    </div>
+                                    <div class="mb-2">
+                                        <small>${created_at}</small>
+                                        <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="${comment_id}"><i class="far fa-trash-alt"></i>削除</button>
+                                    </div>
+                                </div>
+                            </div>
+                        `;
+                }
+
+                //アバター画像があれば
+                else {
+                    html = `
+                            <div class="balloon overflow-hidden my-2 w-100" data-comment-id="${comment_id}">
+                                <div class="balloon_chatting w-100 text-right">
+                                    <a href="/users/${user_id}" class="text-dark mr-auto font-weight-bold"><div class="card-title">${name}<img src="${avatar}" class="rounded-circle ml-1" width="40" height="40" alt="${name}のアバター画像。詳細ぺージへのリンク"></div></a>
+                                    <div class="authenticated_user_comment">
+                                        <p>${comment}</p>
+                                    </div>
+                                    <div class="mb-2">
+                                        <small>${created_at}</small>
+                                        <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="${comment_id}"><i class="far fa-trash-alt"></i>削除</button>
+                                    </div>
+                                </div>
+                            </div>
+                            `;
+                }
+
+                //コメントエリアに先頭にコメントを追加
+                $('#comment_area').prepend(html);
+
+                //一番最後のページのコメントを取得したらここの処理は入らない
+                if ($('.balloon').length !== data['comment_count']) {
+
+                    //各ページの最後のコメントをコメントが投稿されるたびにコンテンツから削除
+                    //次ページを読みこんだ際重複するため(1ページ11コメント)
+                    if ($('.balloon').length % 11 === 1) {
+                        $('#comment_area .balloon:last').detach();
+                    }
+                }
+            })
+            .fail(function(jqXHR, textStatus, errorThrown) {
+
+                //もし前のバリデーションエラーメッセージが残っていれば
+                //メッセージを削除
+                if ($('.invalid-feedback').length) {
+                    $('.invalid-feedback').remove();
+                }
+
+                //失敗フラッシュメッセージを表示
+                toastr.error('コメント投稿に失敗しました');
+
+                let text = $.parseJSON(jqXHR.responseText);
+
+                //バリデーションエラーメッセージ取得
+                let errors = text.errors;
+                for (let key in errors) {
+
+                    //繰り返してメッセージをコードに挿入
+                    let errorMessage = errors[key][0];
+                    let error_html = `
+                                        <span class="invalid-feedback" role="alert">
+                                            <strong>${errorMessage}</strong>
+                                        </span>
+                                    `;
+
+                    //失敗したことを明示するスタイルを追加
+                    //エラーメッセージを追加
+                    $('#comment').addClass('is-invalid');
+                    $('#comment_msg_error').append(error_html);
+                }
+            });
+        }
+    });
+
+    //コメント削除
+    $(document).on('click', '.comment_delete', function() {
+        let $this = $(this);
+
+        //ダイアログでokが押された場合コメント削除処理に入る
+        if(comment_delete_dialog(true)) {
+
+            //二重送信防止用のスタイルを追加
+            $this.css('pointer-events','none');
+
+            //コメントidを取得
+            let d_comment_id = $this.attr('data-id');
+
+            //投稿idを取得
+            let post_id = $('#post_id').val();
+
+            //コメントの要素数を取得
+            let comment_length = $('.balloon').length;
+            $.ajax({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                },
+                url: '/comments/' + d_comment_id,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    'comment_id': d_comment_id,
+                    'comment_length': comment_length,
+                    'post_id': post_id,
+                    '_method': 'DELETE'
+                }
+            })
+            .done(function(data) {
+                let html = '';
+
+                //コメントの所有者ではなかったらメッセージを表示して処理終了
+                if (data['message']) {
+                    toastr.error(data['message']);
+                    return false;
+                }
+
+                //成功フラッシュメッセージを表示
+                toastr.success('コメントを削除しました');
+
+                //バリデーションエラー明示中であれば一旦バリデーションエラークラス属性を削除
+                if ($('.is-invalid').length) {
+                    $('#comment').removeClass('is-invalid');
+                }
+
+                //ナビゲーションタブのコメントカウント
+                if ($('.p_comment_count_badge').length) {
+                    $('.p_comment_count_badge').text(data['comment_count']);
+                }
+
+                //削除されたコメントをフロント側でも削除
+                $this.parents('.balloon').remove();
+
+                //コメントが0になったらコメントが無い時の表示にし処理終了
+                if (data['comment_count'] === 0) {
+                    let html = `
+                                <div class="d-flex justify-content-center align-items-center no_comment" style="font-size:16px; height:200px; color:rgba(0,0,0,0.4);">
+                                    まだコメントがありません
+                                </div>
+                                `;
+                    $('#comment_area').append(html);
+
+                    //二重送信防止用のスタイル解除
+                    $this.css('pointer-events','');
+                    return false;
+                }
+                /*
+                    ここからはコメントを削除した際に出る
+                    次ページとのコメント差分をエリアに追加する処理
+                */
+
+                //ページが最後であればここの処理は入らない
+                if ($('.balloon').length !== data['comment_count']) {
+
+                    //認証ユーザーID取得
+                    let auth_id = data['auth_id'];
+
+                    //ユーザーのアバター画像がnullの場合は、こちらの画像を使用
+                    let img_src = "/storage/images/default_icon.png";
+
+                    //コメントしたユーザーの情報
+                    let user_id = data['comment']['user']['id'];
+                    let name = data['comment']['user']['name'];
+                    let avatar = data['comment']['user']['avatar'];
+
+                    //コメントの情報
+                    let comment_id = data['comment']['id'];
+                    let comment = nl2br(data['comment']['comment']); //nl2br関数の使用
+                    let created_at = formatDate(new Date(data['comment']['created_at']), 'YYYY/MM/DD hh:mm'); //formatDate関数の使用
+
+                    //認証ユーザーコメントならばこちらのコード生成
+                    if (auth_id === user_id) {
+
+                        //アバター画像がnullならば
+                        if (!avatar) {
+                            html = `
+                                    <div class="balloon overflow-hidden my-2 w-100" data-comment-id="${comment_id}">
+                                        <div class="balloon_chatting w-100 text-right">
+                                            <a href="/users/${user_id}" class="text-dark mr-auto font-weight-bold"><div class="card-title">${name}<img src="${img_src}" class="rounded-circle ml-1" width="40" height="40" alt="${name}のアバター画像。詳細ぺージへのリンク"></div></a>
+                                            <div class="authenticated_user_comment">
+                                                <p>${comment}</p>
+                                            </div>
+                                            <div class="mb-2">
+                                                <small>${created_at}</small>
+                                                <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="${comment_id}"><i class="far fa-trash-alt"></i>削除</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                `;
+                        }
+
+                        //アバター画像があれば
+                        else {
+                            html = `
+                                    <div class="balloon overflow-hidden my-2 w-100" data-comment-id="${comment_id}">
+                                        <div class="balloon_chatting w-100 text-right">
+                                            <a href="/users/${user_id}" class="text-dark mr-auto font-weight-bold"><div class="card-title">${name}<img src="${avatar}" class="rounded-circle ml-1" width="40" height="40" alt="${name}のアバター画像。詳細ぺージへのリンク"></div></a>
+                                            <div class="authenticated_user_comment">
+                                                <p>${comment}</p>
+                                            </div>
+                                            <div class="mb-2">
+                                                <small>${created_at}</small>
+                                                <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="${comment_id}"><i class="far fa-trash-alt"></i>削除</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    `;
+                        }
+                    }
+
+                    //認証ユーザー以外のコメントならばこちらのコード生成
+                    else {
+
+                        //アバター画像がnullならば
+                        if (!avatar) {
+                            html = `
+                                    <div class="balloon overflow-hidden my-2 w-100" data-comment-id="${comment_id}">
+                                        <div class="balloon_chatting overflow-hidden w-100 text-left">
+                                            <a href="/users/${user_id}" class="text-dark mr-auto font-weight-bold"><div class="card-title"><img src="${img_src}" class="rounded-circle mr-1" width="40" height="40" alt="${name}のアバター画像。詳細ぺージへのリンク">${name}</div></a>
+                                            <div class="user_comment">
+                                                <p>${comment}</p>
+                                            </div>
+                                            <div class="mb-4 ml-4">
+                                                <small>${created_at}</small>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    `;
+                        }
+
+                        //アバター画像があれば
+                        else {
+                            html = `
+                                    <div class="balloon overflow-hidden my-2 w-100" data-comment-id="${comment_id}">
+                                        <div class="balloon_chatting overflow-hidden w-100 text-left">
+                                            <a href="/users/${user_id}" class="text-dark mr-auto font-weight-bold"><div class="card-title"><img src="${avatar}" class="rounded-circle mr-1" width="40" height="40" alt="${name}のアバター画像。詳細ぺージへのリンク">${name}</div></a>
+                                            <div class="user_comment">
+                                                <p>${comment}</p>
+                                            </div>
+                                            <div class="mb-4 ml-4">
+                                                <small>${created_at}</small>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    `;
+                        }
+                    }
+
+                    //次ページを読みこんだ際要素が消えているためこの条件式 (1ページ11コメント)
+                    if ($('.balloon').length % 11 === 10) {
+
+                        //コメントエリアの最後にコメントを追加
+                        $('#comment_area').append(html);
+                    }
+
+                    //二重送信防止用のスタイル解除
+                    $this.css('pointer-events','');
+                }
+                /*
+                    ここまでがコメントの追加処理
+                */
+            })
+            .fail(function(data) {
+
+                //失敗フラッシュメッセージを表示
+                toastr.error('コメント削除に失敗しました');
+
+                //二重送信防止用のスタイル解除
+                $this.css('pointer-events','');
+            });
+        }
+
+        //ダイアログのキャンセルを押したら処理終了
+        else {
+            return false;
+        }
+    });
+});

--- a/resources/js/dialog.js
+++ b/resources/js/dialog.js
@@ -1,17 +1,16 @@
 var $ = require('jquery');
 
-$(function(){
+//コメント削除ダイアログ関数
+export function comment_delete_dialog() {
+    if(confirm('コメントを削除してよろしいですか？')) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
 
-    //コメント削除ダイヤログ
-    $(document).on('click', '.comment_delete_alert', function() {
-        var $this = $(this);
-        if(confirm('コメントを削除してよろしいですか？')) {
-            $this.submit();
-        }
-        else {
-            return false;
-        }
-    });
+$(function(){
 
     //投稿削除ダイヤログ
     $(document).on('click', '.post_delete_alert', function() {

--- a/resources/js/format_date.js
+++ b/resources/js/format_date.js
@@ -1,0 +1,22 @@
+//データ年月日フォーマット関数
+export function formatDate(date, format) {
+
+    // 年
+    format = format.replace(/YYYY/g, date.getFullYear());
+
+    //月
+    format = format.replace(/MM/g, ('0' + (date.getMonth() + 1)).slice(-2));
+
+    //日
+    format = format.replace(/DD/g, ('0' + date.getDate()).slice(-2));
+
+    //時
+    format = format.replace(/hh/g, ('0' + date.getHours()).slice(-2));
+
+    //分
+    format = format.replace(/mm/g, ('0' + date.getMinutes()).slice(-2));
+
+    //秒
+    format = format.replace(/ss/g, ('0' + date.getSeconds()).slice(-2));
+    return format;
+}

--- a/resources/js/infinite_scroll.js
+++ b/resources/js/infinite_scroll.js
@@ -1,23 +1,30 @@
+var $ = require('jquery');
+var jQueryBridget = require('jquery-bridget');
 var InfiniteScroll = require('infinite-scroll');
 
-var user_list = document.getElementById('user_list');
-var infScroll = new InfiniteScroll( user_list, {
-    path: '.pagination_next',
-    append: '.user_card',
-    history: false,
-    button: '.view_more_button',
-    scrollThreshold: false,
-    hideNav: '.pagination',
-    status: '.page_load_status',
+jQueryBridget( 'infiniteScroll', InfiniteScroll, $ );
+
+//ユーザー一覧、フォロー一覧、フォロワー一覧
+$(function() {
+    $('#user_list').infiniteScroll({
+        path: '.pagination_next',
+        append: '.user_card',
+        history: false,
+        button: '.view_more_button',
+        scrollThreshold: false,
+        hideNav: '.pagination',
+        status: '.page_load_status',
+    });
 });
 
-var comment_area = document.getElementById('comment_area');
-var infScroll = new InfiniteScroll( comment_area, {
-    path: '.comment_next',
-    append: '.balloon',
-    history: false,
-    button: '.comment_more_button',
-    scrollThreshold: false,
-    hideNav: '.pagination',
-    status: '.page_load_status',
+
+//コメント一覧
+$(function() {
+    $('#comment_area').infiniteScroll({
+        path: '.comment_next',
+        append: '.balloon',
+        history: false,
+        hideNav: '.pagination',
+        status: '.page_load_status',
+    });
 });

--- a/resources/js/nl2br.js
+++ b/resources/js/nl2br.js
@@ -1,0 +1,7 @@
+//textarea等で作成保存したデータの表示
+//nl2br()の表示のような関数
+export function nl2br(str) {
+    str = str.replace(/\r\n/g, "<br />");
+    str = str.replace(/(\n|\r)/g, "<br />");
+    return str;
+}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -205,7 +205,6 @@
     max-width:530px;
     max-height:430px;
   }
-
 }
 
 //lgサイズ
@@ -550,11 +549,12 @@ textarea {
   position: relative; 
   margin: 0 0 0 20px;
   padding: 8px;
-  //max-width: 505px;
+  min-width: 30px;
   border-radius: 12px;
   background: #edf1ee;
   font-size: 1rem;
   text-align: left;
+  word-break: break-all;
 }
 // 終
 
@@ -577,11 +577,12 @@ textarea {
   position: relative; 
   margin: 0 20px 0 0;
   padding: 8px;
-  //max-width: 505px;
+  min-width: 30px;
   border-radius: 12px;
   background: #7ed957;
   font-size: 1rem;
   text-align: left;
+  word-break: break-all;
 }
 // ここまで　終
 

--- a/resources/views/comments/comment_form.blade.php
+++ b/resources/views/comments/comment_form.blade.php
@@ -2,21 +2,13 @@
     <div class="col-xl-9 col-lg-12 col-md-9 col-12">
         <div class="new_comment_box">
             <span class="new_comment_title">コメント入力</span>
-            <form method="POST" action="{{ route('posts.comment') }}" accept-charset="UTF-8" class="mt-3">
-                @csrf
-                <input type="hidden" name="post_id" value="{{ $post->id }}">
-                <div class="form-group">
-                    <textarea id="comment" name="comment" class="form-control post_comment @error('comment') is-invalid @enderror" autocomplete="comment" placeholder="150字以下で入力してください" rows=8 maxlength="150" autofocus required>{{ old('comment') }}</textarea>
-                    @error('comment')
-                        <span class="invalid-feedback" role="alert">
-                                <strong>{{ $message }}</strong>
-                        </span>
-                    @enderror
-                </div>
-                <div class="form-group mb-2 text-center">
-                    <button type="submit" class="btn btn-outline-success mt-2">コメントする</button>
-                </div>
-            </form>
+            <input type="hidden" name="post_id" id="post_id" value="{{ $post->id }}">
+            <div class="form-group mt-3" id="comment_msg_error">
+                <textarea id="comment" name="comment" class="form-control post_comment" autocomplete="comment" placeholder="150字以下で入力してください" rows=8 maxlength="150" autofocus required>{{ old('comment') }}</textarea>
+            </div>
+            <div class="form-group mb-2 text-center">
+                <button type="button" class="btn btn-outline-success mt-2 comment_button">コメントする</button>
+            </div>
         </div>
     </div>
 </div>

--- a/resources/views/commons/navtabs_post_show.blade.php
+++ b/resources/views/commons/navtabs_post_show.blade.php
@@ -3,7 +3,7 @@
     <li class="nav-item">
         <a href="{{ route('posts.show', ['post' => $post->id]) }}" class="nav-link {{ Request::routeIs('posts.show') ? 'active' : '' }} text-dark">
             コメント
-            <span class="badge badge-white badge-pill">{{ $post->postComments->count() }}</span>
+            <span class="badge badge-white badge-pill p_comment_count_badge">{{ $post->postComments->count() }}</span>
         </a>
     </li>
     {{-- 投稿いいねユーザータブ --}}

--- a/resources/views/posts/comments.blade.php
+++ b/resources/views/posts/comments.blade.php
@@ -1,68 +1,69 @@
-@if (count($comments) > 0)
-    <div class="row justify-content-center">
-        <div class="col-xl-11 col-lg-12 col-md-11">
-            <div class="comment_area" id="comment_area"><!-- コメント一覧全体を囲う-->
-                @foreach ($comments as $comment)
-                    @if (Auth::id() === $comment->user_id)
-                        <!--右コメント(認証ユーザーのコメント)-->
-                        <div class="balloon overflow-hidden my-2 w-100">
-                            <div class="balloon_chatting w-100 text-right">
-                                @empty($comment->user->avatar)
-                                    <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title">{{ $comment->user->name }}<img src="{{ asset('storage/images/default_icon.png') }}" class="rounded-circle ml-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク"></div></a>
-                                @else
-                                    <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title">{{ $comment->user->name }}<img src="{{ $comment->user->avatar }}" class="rounded-circle ml-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク"></div></a>
-                                @endempty
-                                <div class="authenticated_user_comment">
-                                    <p>{!! nl2br(e($comment->comment)) !!}</p>
-                                </div>
-                                <form method="POST" action="{{ route('posts.uncomment', $comment->id) }}" class="mb-3 comment_delete_alert" id="comment_delete_form">
-                                    <small>{{ $comment->created_at->format('Y/m/d H:i') }}</small>
-                                    @method('DELETE')
-                                    @csrf
-                                    <button type="button" class="btn btn-link comment_trash text-danger"><i class="far fa-trash-alt"></i>削除</button>
-                                </form>
+
+<div class="row justify-content-center">
+    <div class="col-xl-11 col-lg-12 col-md-11">
+
+        {{-- コメント一覧全体を囲う --}}
+        <div class="comment_area" id="comment_area">
+            @foreach ($comments as $comment)
+                @if (Auth::id() === $comment->user_id)
+
+                    {{-- 右コメント(認証ユーザーのコメント) --}}
+                    <div class="balloon overflow-hidden my-2 w-100" data-comment-id="{{ $comment->id }}">
+                        <div class="balloon_chatting overflow-hidden w-100 text-right">
+                            @empty($comment->user->avatar)
+                                <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title">{{ $comment->user->name }}<img src="{{ asset('storage/images/default_icon.png') }}" class="rounded-circle ml-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク"></div></a>
+                            @else
+                                <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title">{{ $comment->user->name }}<img src="{{ $comment->user->avatar }}" class="rounded-circle ml-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク"></div></a>
+                            @endempty
+                            <div class="authenticated_user_comment">
+                                <p>{!! nl2br(e($comment->comment)) !!}</p>
+                            </div>
+                            <div class="mb-2">
+                                <small>{{ $comment->created_at->format('Y/m/d H:i') }}</small>
+                                <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="{{ $comment->id }}"><i class="far fa-trash-alt"></i>削除</button>
                             </div>
                         </div>
-                    @else
-                        <!--左コメント(認証ユーザー以外)-->
-                        <div class="balloon overflow-hidden my-2 w-100">
-                            <div class="balloon_chatting w-100 text-left">
-                                @empty($comment->user->avatar)
-                                    <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title"><img src="{{ asset('storage/images/default_icon.png') }}" class="rounded-circle mr-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク">{{ $comment->user->name }}</div></a>
-                                @else
-                                    <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title"><img src="{{ $comment->user->avatar }}" class="rounded-circle mr-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク">{{ $comment->user->name }}</div></a>
-                                @endempty
-                                <div class="user_comment">
-                                    <p>{!! nl2br(e($comment->comment)) !!}</p>
-                                </div>
-                                <div class="mb-4 ml-4">
-                                    <small>{{ $comment->created_at->format('Y/m/d H:i') }}</small>
-                                </div>
+                    </div>
+                @else
+
+                    {{-- 左コメント(認証ユーザー以外のコメント) --}}
+                    <div class="balloon overflow-hidden my-2 w-100"data-comment-id="{{ $comment->id }}">
+                        <div class="balloon_chatting overflow-hidden w-100 text-left">
+                            @empty($comment->user->avatar)
+                                <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title"><img src="{{ asset('storage/images/default_icon.png') }}" class="rounded-circle mr-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク">{{ $comment->user->name }}</div></a>
+                            @else
+                                <a href="{{ route('users.show', $comment->user_id) }}" class="text-dark mr-auto font-weight-bold"><div class="card-title"><img src="{{ $comment->user->avatar }}" class="rounded-circle mr-1" width="40" height="40" alt="{{ $comment->user->name }}のアバター画像。詳細ぺージへのリンク">{{ $comment->user->name }}</div></a>
+                            @endempty
+                            <div class="user_comment">
+                                <p>{!! nl2br(e($comment->comment)) !!}</p>
+                            </div>
+                            <div class="mb-4 ml-4">
+                                <small>{{ $comment->created_at->format('Y/m/d H:i') }}</small>
                             </div>
                         </div>
-                    @endif
-                @endforeach
-            </div>
+                    </div>
+                @endif
+            @endforeach
+
+            {{-- コメントが無い場合 --}}
+            @if (count($comments) == 0)
+                <div class="d-flex justify-content-center align-items-center no_comment" style="font-size:16px; height:200px; color:rgba(0,0,0,0.4);">
+                    まだコメントがありません
+                </div>
+            @endif
         </div>
     </div>
-    <div class="page_load_status">
-        <div class="loader-ellips infinite-scroll-request">
-            <span class="loader-ellips__dot"></span>
-            <span class="loader-ellips__dot"></span>
-            <span class="loader-ellips__dot"></span>
-            <span class="loader-ellips__dot"></span>
-        </div>
+</div>
+<div class="page_load_status">
+    <div class="loader-ellips infinite-scroll-request">
+        <span class="loader-ellips__dot"></span>
+        <span class="loader-ellips__dot"></span>
+        <span class="loader-ellips__dot"></span>
+        <span class="loader-ellips__dot"></span>
     </div>
-    @if ($comments->hasMorePages())
-        <p class="pagination">
-            <a href="{{ $comments->nextPageUrl() }}" class="comment_next"></a>
-        </p>
-        <p class="text-center mt-3">
-          <button class="comment_more_button btn btn-success btn-lg" aria-pressed="true">もっと見る</button>
-        </p>
-    @endif
-@else
-    <div class="d-flex justify-content-center align-items-center" style="height:200px; color:rgba(0,0,0,0.4);">
-        まだコメントがありません
-    </div>
+</div>
+@if ($comments->hasMorePages())
+    <p class="pagination">
+        <a href="{{ $comments->nextPageUrl() }}" class="comment_next"></a>
+    </p>
 @endif

--- a/tests/Browser/CommentTest.php
+++ b/tests/Browser/CommentTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+use App\User;
+use App\Post;
+use App\Comment;
+
+class CommentTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+    /**
+     * A Dusk test example.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->factory_user = factory(User::class)->create();
+        $this->post = factory(Post::class)->create([
+                    'user_id' => $this->factory_user->id,
+                    ]);
+
+        //複数のコメントを生成
+        $this->comments = factory(Comment::class, 2)->make([
+                            'user_id' => $this->factory_user->id,
+                            'post_id' => $this->post->id,
+                        ]);
+    }
+
+    //コメント投稿テスト
+    public function testCreateComment()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->factory_user)
+                    ->visitRoute('posts.show', $this->post);
+
+            //繰り返してコメントを投稿、投稿されたか確認
+            foreach ($this->comments as $comment) {
+                $browser->type('comment', $comment->comment)
+                        ->press('コメントする')
+                        ->waitForText($comment->comment)
+
+                        //コメントがコンテンツに存在するか確認
+                        ->assertSee($comment->comment)
+
+                        //toastrのフラッシュメッセージが表示されているか確認
+                        ->assertSee('コメント投稿しました'); 
+            }
+            $browser->screenshot('comment');
+        });
+    }
+
+    //コメント未入力での挙動テスト
+    public function testNoComment()
+    {
+        $this->browse(function (Browser $browser) {
+
+            //未入力であることを明示するフラッシュメッセージが表示してあるか確認
+            $browser->loginAs($this->factory_user)
+                    ->visitRoute('posts.show', $this->post)
+
+                    //テキストエリアを未入力
+                    ->type('comment', '')
+                    ->press('コメントする')
+
+                    //toastrのフラッシュメッセージが表示されているか確認
+                    ->assertSee('コメントが未入力です')
+                    ->screenshot('comment');
+        });
+    }
+
+    //コメント削除テスト
+    public function testCommentDelete()
+    {
+        $comment = factory(Comment::class)->create([
+                            'user_id' => $this->factory_user->id,
+                            'post_id' => $this->post->id,
+                        ]);
+        $this->browse(function ($browser) use ($comment) {
+            $browser->loginAs($this->factory_user)
+                    ->visitRoute('posts.show', $this->post)
+
+                    //コメントがコンテンツに存在するか確認
+                    ->assertSee($comment->comment)
+                    ->click('.comment_delete')
+                    ->acceptDialog()
+                    ->pause(1000)
+
+                    //コメントがコンテンツに存在してないか確認
+                    ->assertDontSee($comment->comment)
+
+                    //toastrのフラッシュメッセージが表示されているか確認
+                    ->assertSee('コメントを削除しました')
+
+                     //コメント0状態の表示になっているか確認
+                    ->assertSee('まだコメントがありません')
+                    ->screenshot('comment');
+        });
+    }
+
+    //ナビゲーションタブのコメントカウントテスト
+    public function testCommentCount()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->factory_user)
+                    ->visitRoute('posts.show', $this->post)
+
+                    //コメントがないのでカウントが0であることを確認
+                    ->assertSourceHas('<span class="badge badge-white badge-pill p_comment_count_badge">0</span>')
+                    ->type('comment', $this->comments[0]->comment)
+                    ->press('コメントする')
+                    ->pause(1000)
+
+                    //コメントしたのでカウントが1になったことを確認
+                    ->assertSourceHas('<span class="badge badge-white badge-pill p_comment_count_badge">1</span>')
+                    ->click('.comment_delete')
+                    ->acceptDialog()
+                    ->pause(1000)
+
+                    //コメント削除したのでカウントが0になったことを確認
+                    ->assertSourceHas('<span class="badge badge-white badge-pill p_comment_count_badge">0</span>');
+        });
+    }
+
+    //認証ユーザーか認証ユーザー以外のコメントスタイル表示テスト
+    public function testCommentStyle()
+    {
+        $user = factory(User::class)->create();
+        $comment = factory(Comment::class)->make([
+                            'user_id' => $user->id,
+                            'post_id' => $this->post->id,
+                        ]);
+
+        $this->browse(function ($first, $second) use ($user, $comment) {
+
+            //ユーザー1でログインしコメント投稿
+            //認証ユーザー用のコメントのスタイルで表示されているか確認
+            $first->loginAs($this->factory_user)
+                ->visitRoute('posts.show', $this->post)
+                ->type('comment', $this->comments[0]->comment)
+                ->press('コメントする')
+                ->pause(1000)
+
+                //認証ユーザー用のコメントか確認
+                ->assertPresent('.authenticated_user_comment');
+
+            //ユーザー2でログインしコメント投稿
+            //ユーザー1が投稿したコメントが認証ユーザー以外のスタイルで表示されているか確認
+            $second->loginAs($user)
+                ->visitRoute('posts.show', $this->post)
+
+                //認証ユーザー以外のコメントが表示されており
+                //認証ユーザーのスタイルコメントが表示されていないか確認
+                ->assertPresent('.user_comment')
+                ->assertMissing('.authenticated_user_comment')
+                ->type('comment', $comment->comment)
+                ->press('コメントする')
+                ->pause(1000)
+
+                //コメント投稿して、認証ユーザー用のコメントスタイルで表示されているか確認
+                ->assertPresent('.authenticated_user_comment')
+                ->screenshot('comment');
+        });
+    }
+}

--- a/tests/Browser/ScrollTest.php
+++ b/tests/Browser/ScrollTest.php
@@ -197,8 +197,8 @@ class ScrollTest extends DuskTestCase
                     ->executeScript('window.scrollTo(1000, 2000);');
 
             //スクロールしてページの一番下位にあるコメントを確認
-            $browser->assertSee($comment12)
-                    ->press('もっと見る')
+            $browser->waitForText($comment12)
+                    ->assertSee($comment12)
                     ->driver
                     ->executeScript('window.scrollTo(2500, 3500);');
 

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -64,9 +64,7 @@ class CommentTest extends TestCase
 
         //コメントリクエスト、リダイレクトの確認
         $this->from($url)
-            ->post(route('posts.comment'), $data)
-            ->assertStatus(302)
-            ->assertRedirect($url);
+            ->post(route('posts.comment'), $data);
 
         //データベースにデータが存在するか確認
         $this->assertDatabaseHas('comments', $data);
@@ -76,28 +74,25 @@ class CommentTest extends TestCase
     public function testDeletePostComment()
     {
         $this->actingAs($this->factory_user);
+
         $post_id = $this->post->id;
-        $comment = $this->comment;
+        $comment_id = $this->comment->id;
+
+        $url = route('posts.show', $post_id);
 
         //リクエストする為のデータをまとめる
         $data = [
                 'post_id' => $post_id,
-                'comment' => $comment->comment,
+                'comment_id' => $comment_id,
+                'comment_length' => 4,
             ];
-        $url = route('posts.show', $post_id);
-        $this->post(route('posts.comment'), $data);
 
-        //削除するコメントのモデルのインスタンスを取得
-        $delete_comment = Comment::find($comment->id);
-
-        //コメント削除リクエスト、リダイレクトの確認
+        //コメント削除リクエスト
         $this->from($url)
-            ->delete(route('posts.uncomment', $comment->id))
-            ->assertStatus(302)
-            ->assertRedirect($url);
+            ->delete(route('posts.uncomment', $comment_id), $data);
 
         //コメントがデータベースから削除されたか確認
-        $this->assertDeleted($delete_comment);
+        $this->assertDeleted($this->comment);
     }
 
     //コメントリクエストが、ゲストユーザーができないようになっているかテスト


### PR DESCRIPTION
関連issue #56 

**実装点など**
- コメント投稿・削除非同期
- コメント一覧にコメント追加・削除非同期
- バリデーションレスポンスも非同期
- 半角英数字を改行せず連続して入力したら、コメントのスタイルが崩れる不具合を修正
- コメント一覧の無限スクロールはボタンではなく、下スクロールで発動するように変更
- 機能テストコード修正
- ブラウザテスト実施