### PR TITLE
管理ユーザー機能(コメント削除、投稿削除)

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -23,6 +23,16 @@ class ForgotPasswordController extends Controller
 
     use SendsPasswordResetEmails;
 
+    public function showLinkRequestForm()
+    {
+        //管理ユーザーはアクセスできないよう条件追加
+        if (\Gate::allows('admin')) {
+            return back()
+                ->with('msg_error', '管理ユーザーはパスワード再設定ができません');
+        }
+        return view('auth.passwords.email');
+    }
+
     public function sendResetLinkEmail(ForgotPasswordRequest $request)
     {
         //元々のバリデーションルールを消去

--- a/app/Http/Controllers/Auth/ResetEmailController.php
+++ b/app/Http/Controllers/Auth/ResetEmailController.php
@@ -17,6 +17,11 @@ class ResetEmailController extends Controller
     //メールアドレス変更フォームへ移動
     public function showLinkRequestForm()
     {
+        //管理ユーザーはアクセスできないよう条件追加
+        if (\Gate::allows('admin')) {
+            return back()
+                ->with('msg_error', '管理ユーザーはメールアドレス再設定ができません');
+        }
         return view('auth.emails.email');
     }
 

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -45,6 +45,9 @@ class CommentsController extends Controller
     //コメント所有ユーザーからの、コメント削除リクエスト
     public function destroy(Request $request)
     {
+        //管理ユーザーとしてログインしているか
+        $admin = \Gate::allows('admin');
+
         $comment_id = $request->comment_id;
         $comment_length = $request->comment_length;
         $post_id = $request->post_id;
@@ -54,7 +57,8 @@ class CommentsController extends Controller
         $auth_id = \Auth::id();
 
         //認証ユーザーidとコメントユーザーidを比較
-        if ($auth_id === $select_comment->user_id) {
+        //または管理ユーザーであれば削除処理に入る
+        if ($auth_id === $select_comment->user_id || \Gate::allows('admin')) {
 
             //コメント削除
             $select_comment->delete();
@@ -74,6 +78,7 @@ class CommentsController extends Controller
                     'comment' => $comment,
                     'auth_id' => $auth_id,
                     'comment_count' => $comment_count,
+                    'admin' => $admin,
                     ]);
         }
         else {

--- a/app/Http/Controllers/LikesController.php
+++ b/app/Http/Controllers/LikesController.php
@@ -14,28 +14,14 @@ class LikesController extends Controller
         $like = $user->like($id);
         $post = Post::findOrFail($id);
 
-        //いいね登録の場合
-        if ($like === true) {
-            $p_count = $post->likes()->count();
-            $u_count = $user->likes()->count();
-            return response()->json([
-                            'like' => true,
-                            'p_count' => $p_count,
-                            'u_count' => $u_count,
-                            'auth_id' => $auth_id,
-                        ]);
-        }
-
-        //いいね解除の場合
-        elseif ($like === false) {
-            $p_count = $post->likes()->count();
-            $u_count = $user->likes()->count();
-            return response()->json([
-                            'unlike' => false,
-                            'p_count' => $p_count,
-                            'u_count' => $u_count,
-                            'auth_id' => $auth_id,
-                        ]);
-        }
+        //いいね登録はtrue,いいね解除はfalseを返す
+        $p_count = $post->likes()->count();
+        $u_count = $user->likes()->count();
+        return response()->json([
+                        'like' => $like == true ?? $like == false,
+                        'p_count' => $p_count,
+                        'u_count' => $u_count,
+                        'auth_id' => $auth_id,
+                    ]);
     }
 }

--- a/app/Http/Controllers/LikesController.php
+++ b/app/Http/Controllers/LikesController.php
@@ -9,19 +9,26 @@ class LikesController extends Controller
 {
     public function store($id)
     {
-        $user = \Auth::user();
-        $auth_id = $user->id;
-        $like = $user->like($id);
-        $post = Post::findOrFail($id);
-
-        //いいね登録はtrue,いいね解除はfalseを返す
-        $p_count = $post->likes()->count();
-        $u_count = $user->likes()->count();
-        return response()->json([
-                        'like' => $like == true ?? $like == false,
-                        'p_count' => $p_count,
-                        'u_count' => $u_count,
-                        'auth_id' => $auth_id,
+        if (!\Gate::allows('admin')) {
+            $user = \Auth::user();
+            $auth_id = $user->id;
+            $like = $user->like($id);
+            $post = Post::findOrFail($id);
+    
+            //いいね登録はtrue,いいね解除はfalseを返す
+            $p_count = $post->likes()->count();
+            $u_count = $user->likes()->count();
+            return response()->json([
+                            'like' => $like == true ?? $like == false,
+                            'p_count' => $p_count,
+                            'u_count' => $u_count,
+                            'auth_id' => $auth_id,
+                        ]);
+        }
+        else {
+            return response()->json([
+                        'error' => '管理ユーザーはいいねができません',
                     ]);
+        }
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -194,11 +194,13 @@ class PostsController extends Controller
     public function destroy($id)
     {
         $post = Post::findOrFail($id);
-        
-        if (\Auth::id() === $post->user_id) {
+
+        //投稿所有者と管理ユーザーは投稿削除可能
+        if (\Auth::id() === $post->user_id || \Gate::allows('admin')) {
             foreach ($post->postImages as $post_image) {
                 if (!empty($post_image->image)) {
-                    //既存ファイルの削除
+
+                    //s3内の既存ファイルの削除
                     Storage::disk('s3')->delete('post_images/'.basename($post_image->image));
                 }
             }

--- a/app/Http/Controllers/UserFollowController.php
+++ b/app/Http/Controllers/UserFollowController.php
@@ -7,36 +7,31 @@ use App\User;
 
 class UserFollowController extends Controller
 {
-    public function store($id) {
-        $user = \Auth::user();
-        $auth_id = $user->id;
-        $follow = $user->follow($id);
-        $follower_count = User::findOrFail($id)->followers()->count();
+    public function store($id)
+    {
 
-        //フォローの場合
-        if ($follow === true) {
+        //管理ユーザーはこちらの処理に入れない
+        if (!\Gate::allows('admin')) {
+            $user = \Auth::user();
+            $auth_id = $user->id;
+            $follow = $user->follow($id);
+            $follower_count = User::findOrFail($id)->followers()->count();
+
+            //trueはフォロー、falseはアンフォロー
             $auth_follow_count = $user->followings()->count();
             $auth_follower_count = $user->followers()->count();
             return response()->json([
-                            'follow' => true,
+                            'follow' => $follow == true ?? $follow == false,
                             'follower_count' => $follower_count,
                             'auth_follow_count' => $auth_follow_count,
                             'auth_follower_count' => $auth_follower_count,
                             'auth_id' => $auth_id,
                         ]);
         }
-
-        //アンフォローの場合
-        elseif ($follow === false) {
-            $auth_follow_count = $user->followings()->count();
-            $auth_follower_count = $user->followers()->count();
+        else {
             return response()->json([
-                            'unfollow' => false,
-                            'follower_count' => $follower_count,
-                            'auth_follow_count' => $auth_follow_count,
-                            'auth_follower_count' => $auth_follower_count,
-                            'auth_id' => $auth_id,
-                        ]);
+                        'error' => '管理ユーザーはフォローができません',
+                    ]);
         }
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -25,6 +25,14 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        //管理者は一意である下記メールアドレスが条件
+        Gate::define('admin', function ($user) {
+            return $user->email === 'admin@example.com';
+        });
+
+        //簡単ログインユーザーは一意である下記メールアドレスが条件
+        Gate::define('guest_login_user', function ($user) {
+            return $user->email === 'guest@example.com';
+        });
     }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48391,7 +48391,14 @@ $(function () {
         'id': user_id
       }
     }).done(function (data) {
-      //認証ユーザーのユーザー詳細ページパス
+      //管理ユーザーがフォローしようとしたら
+      //エラー表示したのち処理終了
+      if (data['error']) {
+        toastr.error(data['error']);
+        return false;
+      } //認証ユーザーのユーザー詳細ページパス
+
+
       var following_path = '/users/' + data['auth_id'] + '/following';
       var follower_path = '/users/' + data['auth_id'] + '/follower'; //認証ユーザー以外のユーザー詳細ページパス
 
@@ -48423,7 +48430,7 @@ $(function () {
             }
           }
       } //アンフォロー成功時
-      else if (data['unfollow'] === false) {
+      else if (data['follow'] === false) {
           toastr.success('フォローを外しました'); //ボタン変更
 
           $this.attr('class', 'follow btn btn-outline-primary btn-sm rounded-pill');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48553,6 +48553,13 @@ $(function () {
         'id': post_id
       }
     }).done(function (data) {
+      //管理ユーザーがいいねしようとしたら
+      //エラー表示したのち処理終了
+      if (data['error']) {
+        toastr.error(data['error']);
+        return false;
+      }
+
       var post = '/posts/' + post_id;
       var p_likes_path = post + '/likes';
       var user = '/users/' + data['auth_id'];

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48247,7 +48247,9 @@ $(function () {
           //認証ユーザーID取得
           var auth_id = data['auth_id']; //ユーザーのアバター画像がnullの場合は、こちらの画像を使用
 
-          var img_src = "/storage/images/default_icon.png"; //コメントしたユーザーの情報
+          var img_src = "/storage/images/default_icon.png"; //管理ユーザーでログインしているか
+
+          var admin = data['admin']; //コメントしたユーザーの情報
 
           var user_id = data['comment']['user']['id'];
           var name = data['comment']['user']['name'];
@@ -48281,7 +48283,15 @@ $(function () {
 
           if ($('.balloon').length % 11 === 10) {
             //コメントエリアの最後にコメントを追加
-            $('#comment_area').append(html);
+            $('#comment_area').append(html); //コメントの所有者ではない且つ管理ユーザーでログインしている場合
+            //コメント削除ボタンが出現
+
+            if (auth_id !== user_id && admin == true) {
+              var admin_html = "\n                                                <button type=\"button\" class=\"btn btn-link comment_trash text-danger comment_delete\" data-id=\"".concat(comment_id, "\"><i class=\"far fa-trash-alt\"></i>\u524A\u9664</button>\n                                            ");
+              var d_admin = $('.balloon:last').find('.mb-4');
+              d_admin.removeClass('ml-4');
+              d_admin.prepend(admin_html);
+            }
           } //二重送信防止用のスタイル解除
 
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48575,7 +48575,7 @@ $(function () {
             }
         }
       } //いいね解除成功時
-      else if (data['unlike'] === false) {
+      else if (data['like'] === false) {
           toastr.success('投稿のいいねを外しました'); //アイコンの色変更(白色へ)
 
           $this.attr('class', 'like_button btn btn like_icon far fa-heart fa-lg');

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=af13b8c73717eaf441b6",
+    "/js/app.js": "/js/app.js?id=fa38612f55de0f47f0d3",
     "/css/app.css": "/css/app.css?id=71b848ee122bee673c89"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=c44c7253bc3b86726389",
+    "/js/app.js": "/js/app.js?id=af13b8c73717eaf441b6",
     "/css/app.css": "/css/app.css?id=71b848ee122bee673c89"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=fa38612f55de0f47f0d3",
+    "/js/app.js": "/js/app.js?id=e4d974a3593523e78a02",
     "/css/app.css": "/css/app.css?id=71b848ee122bee673c89"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=e4d974a3593523e78a02",
+    "/js/app.js": "/js/app.js?id=d8ff2e1abaf07d504534",
     "/css/app.css": "/css/app.css?id=71b848ee122bee673c89"
 }

--- a/resources/js/comment.js
+++ b/resources/js/comment.js
@@ -238,6 +238,9 @@ $(function() {
                     //ユーザーのアバター画像がnullの場合は、こちらの画像を使用
                     let img_src = "/storage/images/default_icon.png";
 
+                    //管理ユーザーでログインしているか
+                    let admin = data['admin'];
+
                     //コメントしたユーザーの情報
                     let user_id = data['comment']['user']['id'];
                     let name = data['comment']['user']['name'];
@@ -331,6 +334,17 @@ $(function() {
 
                         //コメントエリアの最後にコメントを追加
                         $('#comment_area').append(html);
+
+                        //コメントの所有者ではない且つ管理ユーザーでログインしている場合
+                        //コメント削除ボタンが出現
+                        if (auth_id !== user_id && admin == true) {
+                            let admin_html = `
+                                                <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="${comment_id}"><i class="far fa-trash-alt"></i>削除</button>
+                                            `;
+                            let d_admin = $('.balloon:last').find('.mb-4');
+                            d_admin.removeClass('ml-4');
+                            d_admin.prepend(admin_html);
+                        }
                     }
 
                     //二重送信防止用のスタイル解除

--- a/resources/js/follow_button.js
+++ b/resources/js/follow_button.js
@@ -25,6 +25,13 @@ $(function() {
         })
         .done(function(data) {
 
+            //管理ユーザーがフォローしようとしたら
+            //エラー表示したのち処理終了
+            if (data['error']) {
+                toastr.error(data['error']);
+                return false;
+            }
+
             //認証ユーザーのユーザー詳細ページパス
             var following_path = '/users/' + data['auth_id'] + '/following';
             var follower_path = '/users/' + data['auth_id'] + '/follower';
@@ -69,7 +76,7 @@ $(function() {
             }
 
             //アンフォロー成功時
-            else if (data['unfollow'] === false) {
+            else if (data['follow'] === false) {
                 toastr.success('フォローを外しました');
 
                 //ボタン変更

--- a/resources/js/like_button.js
+++ b/resources/js/like_button.js
@@ -24,6 +24,13 @@ $(function() {
             data: {'id': post_id},
         })
         .done(function(data) {
+
+            //管理ユーザーがいいねしようとしたら
+            //エラー表示したのち処理終了
+            if (data['error']) {
+                toastr.error(data['error']);
+                return false;
+            }
             var post = '/posts/' + post_id;
             var p_likes_path = post + '/likes';
             var user = '/users/' + data['auth_id'];

--- a/resources/js/like_button.js
+++ b/resources/js/like_button.js
@@ -54,7 +54,7 @@ $(function() {
             }
 
             //いいね解除成功時
-            else if (data['unlike'] === false) {
+            else if (data['like'] === false) {
                 toastr.success('投稿のいいねを外しました');
 
                 //アイコンの色変更(白色へ)

--- a/resources/views/commons/navbar.blade.php
+++ b/resources/views/commons/navbar.blade.php
@@ -59,8 +59,12 @@
                             <div class="dropdown-menu dropdown-menu-right navbar-light" aria-labelledby="navbarDropdown">
                                 <a class="dropdown-item" href="{{ url('/') }}"><i class="fas fa-home fa-lg toppage_icon"></i>トップページ</a>
                                 <a class="dropdown-item" href="{{ route('users.show', Auth::user()->id) }}"><i class="fas fa-address-card fa-lg profile_icon"></i>マイプロフィール</a>
-                                <a class="dropdown-item" href="{{ route('email.request') }}"><i class="fas fa-cog fa-lg email_reset_icon"></i>メールアドレス再設定</a>
-                                <a class="dropdown-item" href="{{ route('password.request') }}"><i class="fas fa-key fa-lg password_reset_icon"></i>パスワード再設定</a>
+
+                                {{-- 管理ユーザーはメールアドレス変更、パスワード変更フォームにアクセスできない --}}
+                                @cannot('admin')
+                                    <a class="dropdown-item" href="{{ route('email.request') }}"><i class="fas fa-cog fa-lg email_reset_icon"></i>メールアドレス再設定</a>
+                                    <a class="dropdown-item" href="{{ route('password.request') }}"><i class="fas fa-key fa-lg password_reset_icon"></i>パスワード再設定</a>
+                                @endcannot
                                 <a class="dropdown-item logout_alert" href="#">
                                     <i class="fas fa-sign-out-alt fa-lg logout_icon"></i>
                                     {{ __('Logout') }}

--- a/resources/views/likes/like_button.blade.php
+++ b/resources/views/likes/like_button.blade.php
@@ -1,4 +1,4 @@
-@if(Auth::check())
+@if(Auth::check() && !Gate::allows('admin'))
     <button type="button" class="like_button btn btn 
         {{ Auth::user()->isLike($post->id)? 'like_now_icon fas fa-heart' : 'like_icon far fa-heart' }} 
         fa-lg" data-id="{{ $post->id }}">

--- a/resources/views/posts/comments.blade.php
+++ b/resources/views/posts/comments.blade.php
@@ -37,7 +37,10 @@
                             <div class="user_comment">
                                 <p>{!! nl2br(e($comment->comment)) !!}</p>
                             </div>
-                            <div class="mb-4 ml-4">
+                            <div class="mb-4 @cannot('admin') ml-4 @endcannot">
+                                @can('admin')
+                                    <button type="button" class="btn btn-link comment_trash text-danger comment_delete" data-id="{{ $comment->id }}"><i class="far fa-trash-alt"></i>削除</button>
+                                @endcan
                                 <small>{{ $comment->created_at->format('Y/m/d H:i') }}</small>
                             </div>
                         </div>

--- a/resources/views/posts/information.blade.php
+++ b/resources/views/posts/information.blade.php
@@ -22,6 +22,8 @@
         <div class="d-flex justify-content-end mt-3">
             @if(Auth::id() === $post->user_id)
                 <a href="{{ route('posts.edit', $post->id) }}" class="d-block justify-content-start"><button class="btn btn-outline-success btn-sm rounded-pill fas fa-edit mt-1">編集</button></a>
+            @endif
+            @if(Auth::id() === $post->user_id || Gate::allows('admin'))
                 <form method="POST" action="{{ route('posts.destroy', $post->id) }}" class="mr-auto post_delete_alert" id="post_delete_form">
                     @method('DELETE')
                     @csrf

--- a/resources/views/user_follow/follow_button.blade.php
+++ b/resources/views/user_follow/follow_button.blade.php
@@ -1,4 +1,4 @@
-@if(Auth::check())
+@if(Auth::check() && !Gate::allows('admin'))
     @if(Auth::id() != $user->id)
         @if(Auth::user()->isFollowing($user->id))
             {{-- アンフォローボタン --}}

--- a/tests/Browser/EmailResetTest.php
+++ b/tests/Browser/EmailResetTest.php
@@ -107,4 +107,37 @@ class EmailResetTest extends DuskTestCase
                 ->assertPathIs('/email/reset');
         });
     }
+
+    //管理ユーザーは、メールアドレス再設定フォームにアクセスできないかテスト
+    //リダイレクトの確認
+    //失敗フラッシュメッセージが表示されているか確認
+    public function testAdminInaccessibleEmailResetPage()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->browse(function ($browser) use ($admin) {
+            $browser->loginAs($admin)
+                    ->visit('/')
+                    ->visitRoute('email.request')
+                    ->assertPathIs('/')
+                    ->assertSee('管理ユーザーはメールアドレス再設定ができません')
+                    ->screenshot('email_reset');
+        });
+    }
+
+    //ナビゲーションバーにメールアドレス再設定フォームのリンクが表示されていないかテスト
+    public function testNavbarEmailResetLinkNotDisplayed()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->browse(function ($browser) use ($admin) {
+            $browser->loginAs($admin)
+                    ->visit('/')
+                    ->click('#navbarDropdown')
+                    ->assertMissing('.email_reset_icon')
+                    ->screenshot('email_reset');
+        });
+    }
 }

--- a/tests/Browser/FollowTest.php
+++ b/tests/Browser/FollowTest.php
@@ -110,4 +110,17 @@ class FollowTest extends DuskTestCase
                     ->screenshot('follow');
         });
     }
+
+    //管理ユーザーでログインしたら、フォローボタンが表示されていないかテスト
+    public function testNotDisplayedFollowButton()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->browse(function ($browser) use ($admin) {
+            $browser->loginAs($admin)
+                    ->visitRoute('users.index')
+                    ->assertSourceMissing('<button type="button" class="follow btn btn-outline-primary btn-sm rounded-pill">フォロー</button>');
+        });
+    }
 }

--- a/tests/Browser/LikeTest.php
+++ b/tests/Browser/LikeTest.php
@@ -191,4 +191,19 @@ class LikeTest extends DuskTestCase
                     ->screenshot('like');
         });
     }
+
+    //管理ユーザーはいいねボタンがいいねできないようになっているかテスト
+    //カウントは増えていないか
+    public function testCannotAdminPostLike()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->browse(function ($browser) use ($admin) {
+            $browser->loginAs($admin)
+                    ->visit('/')
+                    ->click('.far')
+                    ->assertSourceHas('<span class="align-self-end">0</span>');
+        });
+    }
 }

--- a/tests/Browser/PasswordResetTest.php
+++ b/tests/Browser/PasswordResetTest.php
@@ -163,4 +163,37 @@ class PasswordResetTest extends DuskTestCase
                     ->screenshot('password_reset');
         });
     }
+
+    //管理ユーザーは、パスワード再設定フォームにアクセスできないかテスト
+    //リダイレクトの確認
+    //失敗フラッシュメッセージが表示されているか確認
+    public function testAdminInaccessiblePasswordResetPage()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->browse(function ($browser) use ($admin) {
+            $browser->loginAs($admin)
+                    ->visit('/')
+                    ->visitRoute('password.request')
+                    ->assertPathIs('/')
+                    ->assertSee('管理ユーザーはパスワード再設定ができません')
+                    ->screenshot('password_reset');
+        });
+    }
+
+    //ナビゲーションバーにパスワード再設定フォームのリンクが表示されていないかテスト
+    public function testNavbarPasswordResetLinkNotDisplayed()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->browse(function ($browser) use ($admin) {
+            $browser->loginAs($admin)
+                    ->visit('/')
+                    ->click('#navbarDropdown')
+                    ->assertMissing('.password_reset_icon')
+                    ->screenshot('password_reset');
+        });
+    }
 }

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -265,8 +265,38 @@ class CommentTest extends TestCase
     }
 
     //ゲストユーザーにはコメント入力エリアが表示されていないかテスト
-    public function testCommentTextArea() {
+    public function testCommentTextArea()
+    {
         $this->get(route('posts.show', $this->post->id))
             ->assertDontSee('<textarea></textarea>');
+    }
+
+    //管理ユーザーが他ユーザーのコメントを削除できるかテスト
+    public function testAdminDeleteComment()
+    {
+        //管理ユーザーでログイン
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->actingAs($admin);
+
+        $post_id = $this->post->id;
+        $comment_id = $this->comment->id;
+
+        $url = route('posts.show', $post_id);
+
+        //リクエストする為のデータをまとめる
+        $data = [
+                'post_id' => $post_id,
+                'comment_id' => $comment_id,
+                'comment_length' => 4,
+            ];
+
+        //コメント削除リクエスト
+        $this->from($url)
+            ->delete(route('posts.uncomment', $comment_id), $data);
+
+        //コメントがデータベースから削除されたか確認
+        $this->assertDeleted($this->comment);
     }
 }

--- a/tests/Feature/EmailResetTest.php
+++ b/tests/Feature/EmailResetTest.php
@@ -288,4 +288,20 @@ class EmailResetTest extends TestCase
                     'new_email' => $data['new_email'],
                 ]);
     }
+
+    //管理ユーザーはメールアドレス再設定フォームにアクセスできないかテスト
+    //リダイレクトの確認
+    //失敗フラッシュメッセージが表示されているか確認
+    public function testAdminInaccessibleEmailResetPage()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->actingAs($admin)
+            ->from('/')
+            ->get(route('email.request'))
+            ->assertStatus(302)
+            ->assertRedirect('/')
+            ->assertSessionHas('msg_error', '管理ユーザーはメールアドレス再設定ができません');
+    }
 }

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -430,4 +430,20 @@ class PasswordResetTest extends TestCase
         //どこがエラーになったのか検証
         $this->assertEquals($expectedFailed, $validator->failed());
     }
+
+    //管理ユーザーはパスワード再設定フォームにアクセスできないかテスト
+    //リダイレクトの確認
+    //失敗フラッシュメッセージが表示されているか確認
+    public function testAdminInaccessiblePasswordResetPage()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $this->actingAs($admin)
+            ->from('/')
+            ->get(route('password.request'))
+            ->assertStatus(302)
+            ->assertRedirect('/')
+            ->assertSessionHas('msg_error', '管理ユーザーはパスワード再設定ができません');
+    }
 }

--- a/tests/Feature/PostEditTest.php
+++ b/tests/Feature/PostEditTest.php
@@ -30,7 +30,7 @@ class PostEditTest extends TestCase
 
         //一つの投稿と関係リレーションデータ同時生成
         $this->factory_user = factory(User::class)->create();
-        $this->posts = factory(Post::class)->create([
+        $this->posts = factory(Post::class, 1)->create([
                     'user_id' => $this->factory_user->id,
                     ])
                     ->each(function ($post) {
@@ -329,5 +329,24 @@ class PostEditTest extends TestCase
         
         //データが真であるか確認
         $this->assertTrue($result);
+    }
+
+    //管理ユーザーでログイン
+    //管理ユーザーで投稿削除可能かテスト
+    //成功フラッシュメッセージが表示されているか確認
+    public function testAdminDeletePost()
+    {
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+        $url = route('posts.show', $this->posts[0]);
+
+        //管理ユーザーでログイン
+        $this->actingAs($admin)
+            ->from($url)
+            ->delete(route('posts.destroy', $this->posts[0]))
+            ->assertStatus(302)
+            ->assertRedirect('/')
+            ->assertSessionHas('msg_success', '投稿削除しました');
     }
 }


### PR DESCRIPTION
関連issue #64 

**実装点など**
- 管理者権限認可
- 管理者による全コメント削除権限
- 管理者による全投稿削除権限
- 管理ユーザーはいいね、フォロー、メールアドレス再設定、パスワード再設定使用不可に
- 仕様変更によるテスト項目追加