### PR TITLE
ユーザー一覧ページに管理ユーザーは非表示設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="{{ asset('storage/images/logo.png') }}" width="400"></p>
+<p align="center"><img src="https://user-images.githubusercontent.com/65531136/95590284-d6287780-0a80-11eb-9fd0-a46974a14466.png" max-width="400" max-height="100"></p>
 
 ## アプリ概要
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -18,8 +18,12 @@ class UsersController extends Controller
      */
     public function index()
     {
-        $users = User::orderBy('id', 'desc')->simplePaginate(12);
-        
+        //管理ユーザーのデータを取得しない(一意であるメールアドレスで判定)
+        //管理ユーザーはユーザー一覧に表示しない
+        $users = User::whereNotIn('email', ['admin@example.com'])
+                    ->orderBy('id', 'desc')
+                    ->simplePaginate(12);
+
         return view('users.index', [
             'users' => $users,
         ]);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48582,25 +48582,29 @@ var InfiniteScroll = __webpack_require__(/*! infinite-scroll */ "./node_modules/
 jQueryBridget('infiniteScroll', InfiniteScroll, $); //ユーザー一覧、フォロー一覧、フォロワー一覧
 
 $(function () {
-  $('#user_list').infiniteScroll({
-    path: '.pagination_next',
-    append: '.user_card',
-    history: false,
-    button: '.view_more_button',
-    scrollThreshold: false,
-    hideNav: '.pagination',
-    status: '.page_load_status'
-  });
+  if ($('.pagination_next').length) {
+    $('#user_list').infiniteScroll({
+      path: '.pagination_next',
+      append: '.user_card',
+      history: false,
+      button: '.view_more_button',
+      scrollThreshold: false,
+      hideNav: '.pagination',
+      status: '.page_load_status'
+    });
+  }
 }); //コメント一覧
 
 $(function () {
-  $('#comment_area').infiniteScroll({
-    path: '.comment_next',
-    append: '.balloon',
-    history: false,
-    hideNav: '.pagination',
-    status: '.page_load_status'
-  });
+  if ($('.comment_next').length) {
+    $('#comment_area').infiniteScroll({
+      path: '.comment_next',
+      append: '.balloon',
+      history: false,
+      hideNav: '.pagination',
+      status: '.page_load_status'
+    });
+  }
 });
 
 /***/ }),
@@ -48735,7 +48739,6 @@ imagesLoaded.makeJQueryPlugin($); //トップページ、個別ユーザー投�
 $(function () {
   var $post_card_container = $('#post_card_container').masonry({
     itemSelector: 'none',
-    // select none at first
     columnWidth: '.post_sizer',
     percentPosition: true,
     stagger: 30,
@@ -48757,16 +48760,19 @@ $(function () {
     $post_card_container.masonry('appended', $items);
   });
   InfiniteScroll.imagesLoaded = imagesLoaded;
-  $post_card_container.infiniteScroll({
-    path: '.pagination_next',
-    append: '.post_item',
-    outlayer: msnry,
-    button: '.view_more_button',
-    history: false,
-    scrollThreshold: false,
-    hideNav: '.pagination',
-    status: '.page_load_status'
-  });
+
+  if ($('.pagination_next').length) {
+    $post_card_container.infiniteScroll({
+      path: '.pagination_next',
+      append: '.post_item',
+      outlayer: msnry,
+      button: '.view_more_button',
+      history: false,
+      scrollThreshold: false,
+      hideNav: '.pagination',
+      status: '.page_load_status'
+    });
+  }
 });
 
 /***/ }),

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=28b44bcd015b478dd52a",
+    "/js/app.js": "/js/app.js?id=7f36d769b0351ffd18db",
     "/css/app.css": "/css/app.css?id=6686d6bcfd8f1b59d6c2"
 }

--- a/resources/js/infinite_scroll.js
+++ b/resources/js/infinite_scroll.js
@@ -6,25 +6,29 @@ jQueryBridget( 'infiniteScroll', InfiniteScroll, $ );
 
 //ユーザー一覧、フォロー一覧、フォロワー一覧
 $(function() {
-    $('#user_list').infiniteScroll({
-        path: '.pagination_next',
-        append: '.user_card',
-        history: false,
-        button: '.view_more_button',
-        scrollThreshold: false,
-        hideNav: '.pagination',
-        status: '.page_load_status',
-    });
+    if ($('.pagination_next').length) {
+        $('#user_list').infiniteScroll({
+            path: '.pagination_next',
+            append: '.user_card',
+            history: false,
+            button: '.view_more_button',
+            scrollThreshold: false,
+            hideNav: '.pagination',
+            status: '.page_load_status',
+        });
+    }
 });
 
 
 //コメント一覧
 $(function() {
-    $('#comment_area').infiniteScroll({
-        path: '.comment_next',
-        append: '.balloon',
-        history: false,
-        hideNav: '.pagination',
-        status: '.page_load_status',
-    });
+    if ($('.comment_next').length) {
+        $('#comment_area').infiniteScroll({
+            path: '.comment_next',
+            append: '.balloon',
+            history: false,
+            hideNav: '.pagination',
+            status: '.page_load_status',
+        });
+    }
 });

--- a/resources/js/posts_masonry_layout.js
+++ b/resources/js/posts_masonry_layout.js
@@ -11,7 +11,7 @@ imagesLoaded.makeJQueryPlugin( $ );
 //いいねランキングページ、検索一覧ページ
 $(function() {
   var $post_card_container = $('#post_card_container').masonry({
-    itemSelector: 'none', // select none at first
+    itemSelector: 'none',
     columnWidth: '.post_sizer',
     percentPosition: true,
     stagger: 30,
@@ -29,14 +29,16 @@ $(function() {
 
   InfiniteScroll.imagesLoaded = imagesLoaded;
 
-  $post_card_container.infiniteScroll({
-      path: '.pagination_next',
-      append: '.post_item',
-      outlayer: msnry,
-      button: '.view_more_button',
-      history: false,
-      scrollThreshold: false,
-      hideNav: '.pagination',
-      status: '.page_load_status',
-  });
+  if ($('.pagination_next').length) {
+    $post_card_container.infiniteScroll({
+        path: '.pagination_next',
+        append: '.post_item',
+        outlayer: msnry,
+        button: '.view_more_button',
+        history: false,
+        scrollThreshold: false,
+        hideNav: '.pagination',
+        status: '.page_load_status',
+    });
+  }
 });

--- a/tests/Browser/ScrollTest.php
+++ b/tests/Browser/ScrollTest.php
@@ -107,16 +107,22 @@ class ScrollTest extends DuskTestCase
     //ユーザー一覧の無限スクロールテスト
     public function testUsersScroll(): void
     {
+        //管理ユーザーの生成
+        $admin = factory(User::class)->create([
+                        'email' => 'admin@example.com',
+                    ]);
         $user1 = $this->users[0]->name;
         $user3 = $this->users[2]->name;
         $user14 = $this->users[13]->name;
 
-        $this->browse(function ($browser) use ($user1, $user3, $user14) {
+        $this->browse(function ($browser) use ($admin, $user1, $user3, $user14) {
 
             //ページの一番上位にあるユーザーを確認
+            //管理ユーザーが一覧に表示されていないか確認
             $browser->visitRoute('users.index')
                     ->waitForText($user14)
                     ->assertSee($user14)
+                    ->assertDontSee($admin->name)
                     ->driver
                     ->executeScript('window.scrollTo(0, 500);');
 
@@ -128,7 +134,9 @@ class ScrollTest extends DuskTestCase
                     ->executeScript('window.scrollTo(1000, 2000);');
 
             //もっと見るボタン押下げ後、二ページ目のユーザーを確認
+            //管理ユーザーが一覧に表示されていないか確認
             $browser->waitForText($user1)
+                    ->assertDontSee($admin->name)
                     ->assertSee($user1);
         });
     }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -228,4 +228,19 @@ class UserTest extends TestCase
             ->assertViewIs('welcome')
             ->assertSee('さぁ、動物たちの笑っている表情を');
     }
+
+    //ユーザー一覧にアクセスする際に
+    //管理ユーザーのデータをコントローラーで取得していないかテスト
+    public function testAdminUserNotUserList(): void
+    {
+        $users = factory(User::class, 10)->create();
+        $admin = factory(User::class)->create([
+                    'email' => 'admin@example.com',
+                ]);
+
+        //レスポンスデータに管理ユーザーのデータがないか確認
+        $this->get(route('users.index'))
+            ->assertViewIs('users.index')
+            ->assertDontSee($admin->name);
+    }
 }


### PR DESCRIPTION
close #78 

**修正点など**
- ユーザー一覧ページに管理ユーザーを非表示にするよう、コントローラー処理にコード追加
- chromeデペロッパーツールのコンソールに、要素がない際エラーが表示されていたので、無限スクロールjsファイルコード修正
- README更新